### PR TITLE
[NO-TICKET] Add Telegram alert when campaign emails exhaust max retries

### DIFF
--- a/app/business/newsletter/campaign-tracking.server.test.ts
+++ b/app/business/newsletter/campaign-tracking.server.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockLogger = { error: vi.fn() }
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: mockLogger,
+}))
+
+const mockExecute = vi.fn().mockResolvedValue([])
+const mockExecuteTakeFirst = vi.fn().mockResolvedValue(null)
+
+vi.mock("~/kysely-db", () => ({
+  kyselyDb: {
+    updateTable: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          where: vi.fn(() => ({
+            execute: mockExecute,
+          })),
+        })),
+      })),
+    })),
+    selectFrom: vi.fn(() => ({
+      selectAll: vi.fn(() => ({
+        where: vi.fn(() => ({
+          where: vi.fn(() => ({
+            executeTakeFirst: mockExecuteTakeFirst,
+          })),
+        })),
+      })),
+    })),
+    insertInto: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflict: vi.fn(() => ({
+          execute: mockExecute,
+        })),
+      })),
+    })),
+  },
+}))
+
+vi.mock("~/lib/helpers/kysely-helpers", () => ({
+  json: vi.fn((v: unknown) => v),
+}))
+
+describe("updateCampaignError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should log error at error level when max retries reached", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      times_attempted: 3,
+      campaign_type: "opening",
+    })
+
+    const { updateCampaignError } = await import(
+      "./campaign-tracking.server"
+    )
+
+    const errorData = {
+      step: "campaign_creation" as const,
+      message: "fetch failed",
+      timestamp: "2026-03-25T14:00:00.000Z",
+    }
+
+    await updateCampaignError("event-123", errorData, "opening")
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Campaign email failed after max retries — will not retry again",
+      expect.objectContaining({
+        eventId: "event-123",
+        campaignType: "opening",
+        lastError: "fetch failed",
+      }),
+    )
+  })
+
+  it("should not log error when retries below max", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      times_attempted: 1,
+      campaign_type: "opening",
+    })
+
+    const { updateCampaignError } = await import(
+      "./campaign-tracking.server"
+    )
+
+    const errorData = {
+      step: "campaign_creation" as const,
+      message: "fetch failed",
+      timestamp: "2026-03-25T14:00:00.000Z",
+    }
+
+    await updateCampaignError("event-123", errorData, "opening")
+
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+})

--- a/app/business/newsletter/campaign-tracking.server.test.ts
+++ b/app/business/newsletter/campaign-tracking.server.test.ts
@@ -5,8 +5,8 @@ vi.mock("~/lib/logger/logger.server", () => ({
   logger: mockLogger,
 }))
 
+const mockReturningExecute = vi.fn().mockResolvedValue([])
 const mockExecute = vi.fn().mockResolvedValue([])
-const mockExecuteTakeFirst = vi.fn().mockResolvedValue(null)
 
 vi.mock("~/kysely-db", () => ({
   kyselyDb: {
@@ -15,6 +15,9 @@ vi.mock("~/kysely-db", () => ({
         where: vi.fn(() => ({
           where: vi.fn(() => ({
             execute: mockExecute,
+            returning: vi.fn(() => ({
+              execute: mockReturningExecute,
+            })),
           })),
         })),
       })),
@@ -23,7 +26,7 @@ vi.mock("~/kysely-db", () => ({
       selectAll: vi.fn(() => ({
         where: vi.fn(() => ({
           where: vi.fn(() => ({
-            executeTakeFirst: mockExecuteTakeFirst,
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
           })),
         })),
       })),
@@ -48,10 +51,7 @@ describe("updateCampaignError", () => {
   })
 
   it("should log error at error level when max retries reached", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      times_attempted: 3,
-      campaign_type: "opening",
-    })
+    mockReturningExecute.mockResolvedValueOnce([{ times_attempted: 3 }])
 
     const { updateCampaignError } = await import(
       "./campaign-tracking.server"
@@ -76,10 +76,25 @@ describe("updateCampaignError", () => {
   })
 
   it("should not log error when retries below max", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      times_attempted: 1,
-      campaign_type: "opening",
-    })
+    mockReturningExecute.mockResolvedValueOnce([{ times_attempted: 1 }])
+
+    const { updateCampaignError } = await import(
+      "./campaign-tracking.server"
+    )
+
+    const errorData = {
+      step: "campaign_creation" as const,
+      message: "fetch failed",
+      timestamp: "2026-03-25T14:00:00.000Z",
+    }
+
+    await updateCampaignError("event-123", errorData, "opening")
+
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it("should not log error when returning gives empty result", async () => {
+    mockReturningExecute.mockResolvedValueOnce([])
 
     const { updateCampaignError } = await import(
       "./campaign-tracking.server"

--- a/app/business/newsletter/campaign-tracking.server.ts
+++ b/app/business/newsletter/campaign-tracking.server.ts
@@ -104,7 +104,7 @@ export const updateCampaignError = composable(
     errorData: CampaignErrorData,
     campaignType: "opening" | "pre_opening",
   ) => {
-    await kyselyDb
+    const [updated] = await kyselyDb
       .updateTable("event_newsletter_campaigns")
       .set((eb) => ({
         times_attempted: eb("times_attempted", "+", 1),
@@ -114,14 +114,8 @@ export const updateCampaignError = composable(
       }))
       .where("event_id", "=", eventId)
       .where("campaign_type", "=", campaignType)
+      .returning(["times_attempted"])
       .execute()
-
-    const updated = await kyselyDb
-      .selectFrom("event_newsletter_campaigns")
-      .selectAll()
-      .where("event_id", "=", eventId)
-      .where("campaign_type", "=", campaignType)
-      .executeTakeFirst()
 
     if (updated && updated.times_attempted >= MAX_CAMPAIGN_RETRIES) {
       logger.error(

--- a/app/business/newsletter/campaign-tracking.server.ts
+++ b/app/business/newsletter/campaign-tracking.server.ts
@@ -1,6 +1,9 @@
 import { composable } from "composable-functions"
 import { kyselyDb } from "~/kysely-db"
 import { json } from "~/lib/helpers/kysely-helpers"
+import { logger } from "~/lib/logger/logger.server"
+
+const MAX_CAMPAIGN_RETRIES = 3
 
 type CampaignErrorData = {
   step: "campaign_creation" | "send_signal"
@@ -37,7 +40,7 @@ export const getPendingCampaigns = composable(
       .selectFrom("event_newsletter_campaigns")
       .selectAll()
       .where("campaign_type", "=", campaignType)
-      .where("times_attempted", "<", 3)
+      .where("times_attempted", "<", MAX_CAMPAIGN_RETRIES)
       .where((eb) =>
         eb.or([
           eb("campaign_is_created", "=", false),
@@ -112,6 +115,26 @@ export const updateCampaignError = composable(
       .where("event_id", "=", eventId)
       .where("campaign_type", "=", campaignType)
       .execute()
+
+    const updated = await kyselyDb
+      .selectFrom("event_newsletter_campaigns")
+      .selectAll()
+      .where("event_id", "=", eventId)
+      .where("campaign_type", "=", campaignType)
+      .executeTakeFirst()
+
+    if (updated && updated.times_attempted >= MAX_CAMPAIGN_RETRIES) {
+      logger.error(
+        "Campaign email failed after max retries — will not retry again",
+        {
+          eventId,
+          campaignType,
+          timesAttempted: updated.times_attempted,
+          lastError: errorData.message,
+          step: errorData.step,
+        },
+      )
+    }
 
     return true
   },


### PR DESCRIPTION
## Linear Ticket

Fixes NO-TICKET (related to POS-473)

## Summary

Campaign emails (event opening, pre-opening reminders) were failing silently — after 3 retries, they were abandoned with no notification to admins. This adds a `logger.error()` call when max retries are exhausted, which triggers the Telegram transport and alerts admins immediately.

## How to test manually

1. Force a campaign to fail 3 times (e.g., set `LISTMONK_API_URL` to an invalid URL)
2. Wait for cron to process the campaign 3 times
3. Verify Telegram alert is received with event ID, campaign type, and error details

## Implementation Notes

- Added `logger.error()` in `updateCampaignError()` when `times_attempted >= MAX_CAMPAIGN_RETRIES`
- Extracted magic number `3` into `MAX_CAMPAIGN_RETRIES` constant
- Error log includes: eventId, campaignType, timesAttempted, lastError, step
- Logger error level triggers the existing Telegram transport (when `TELEGRAM_ALERTS_ENABLED=true`)

## Testing

- Unit tests: 2 new tests in `campaign-tracking.server.test.ts`
  - Verifies `logger.error` is called when max retries reached
  - Verifies `logger.error` is NOT called when retries below max
- All 166 test files pass (1574 tests)
- All 3 related integration test files pass (32 tests)
- Lint passes

## Breaking Changes

None