### PR TITLE
[POS-474] Admin Listmonk connection diagnostic tool

### DIFF
--- a/app/business/newsletter/test-listmonk-connection.server.test.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.test.ts
@@ -7,14 +7,16 @@ vi.mock("~/lib/logger/logger.server", () => ({
   logger: { error: vi.fn(), warn: vi.fn() },
 }))
 
+const mockGetListmonkConfig = vi.fn(() => ({
+  listmonkApiUrl: "http://listmonk:9000",
+  headers: {
+    Authorization: "Basic dGVzdDp0ZXN0",
+    "Content-Type": "application/json",
+  },
+}))
+
 vi.mock("./listmonk-client.server", () => ({
-  getListmonkConfig: vi.fn(() => ({
-    listmonkApiUrl: "http://listmonk:9000",
-    headers: {
-      Authorization: "Basic dGVzdDp0ZXN0",
-      "Content-Type": "application/json",
-    },
-  })),
+  getListmonkConfig: () => mockGetListmonkConfig(),
 }))
 
 function jsonResponse(data: unknown, status = 200) {
@@ -158,5 +160,47 @@ describe("cleanupListmonkTestCampaign", () => {
     expect(result.success).toBe(false)
     expect(result.step.status).toBe("error")
     expect(result.step.error).toBeDefined()
+  })
+
+  it("should return structured error when config is missing", async () => {
+    mockGetListmonkConfig.mockImplementationOnce(() => {
+      throw new Error("Listmonk API credentials not configured")
+    })
+
+    const { cleanupListmonkTestCampaign } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    const result = await cleanupListmonkTestCampaign(99)
+
+    expect(result.success).toBe(false)
+    expect(result.step.status).toBe("error")
+    expect(result.step.error).toContain("credentials not configured")
+  })
+})
+
+describe("config errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("testListmonkConnection should return structured error when config is missing", async () => {
+    mockGetListmonkConfig.mockImplementationOnce(() => {
+      throw new Error("Listmonk API credentials not configured")
+    })
+
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(false)
+    expect(result.campaignId).toBeNull()
+    expect(result.steps).toHaveLength(1)
+    expect(result.steps[0].label).toBe("Configuração do Listmonk")
+    expect(result.steps[0].status).toBe("error")
+    expect(result.steps[0].error).toContain("credentials not configured")
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 })

--- a/app/business/newsletter/test-listmonk-connection.server.test.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.test.ts
@@ -32,21 +32,21 @@ describe("testListmonkConnection", () => {
     vi.clearAllMocks()
   })
 
-  it("should return all 4 steps as ok on full success", async () => {
+  it("should return 3 steps as ok on full success and include campaignId", async () => {
     const { testListmonkConnection } = await import(
       "./test-listmonk-connection.server"
     )
 
     mockFetch
-      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection
-      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign
-      .mockReturnValueOnce(jsonResponse({ data: {} })) // send (status running)
-      .mockReturnValueOnce(jsonResponse(null)) // delete campaign
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // ping
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // create campaign
+      .mockReturnValueOnce(jsonResponse({ data: {} })) // send
 
     const result = await testListmonkConnection()
 
     expect(result.success).toBe(true)
-    expect(result.steps).toHaveLength(4)
+    expect(result.campaignId).toBe(99)
+    expect(result.steps).toHaveLength(3)
     expect(result.steps.every((s) => s.status === "ok")).toBe(true)
   })
 
@@ -60,70 +60,49 @@ describe("testListmonkConnection", () => {
     const result = await testListmonkConnection()
 
     expect(result.success).toBe(false)
+    expect(result.campaignId).toBeNull()
     expect(result.steps).toHaveLength(1)
     expect(result.steps[0].status).toBe("error")
     expect(result.steps[0].error).toContain("fetch failed")
   })
 
-  it("should return error at step 2 when campaign creation fails, no cleanup needed", async () => {
+  it("should return error at step 2 when campaign creation fails", async () => {
     const { testListmonkConnection } = await import(
       "./test-listmonk-connection.server"
     )
 
     mockFetch
-      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
-      .mockReturnValueOnce(jsonResponse({ error: "bad request" }, 400)) // createCampaign fails
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // ping ok
+      .mockReturnValueOnce(jsonResponse({ error: "bad request" }, 400)) // create fails
 
     const result = await testListmonkConnection()
 
     expect(result.success).toBe(false)
+    expect(result.campaignId).toBeNull()
     expect(result.steps).toHaveLength(2)
     expect(result.steps[0].status).toBe("ok")
     expect(result.steps[1].status).toBe("error")
     expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 
-  it("should return error at step 3 when send fails, still runs cleanup", async () => {
+  it("should return error at step 3 when send fails but still return campaignId", async () => {
     const { testListmonkConnection } = await import(
       "./test-listmonk-connection.server"
     )
 
     mockFetch
-      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
-      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign ok
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // ping ok
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // create ok
       .mockReturnValueOnce(jsonResponse({ error: "timeout" }, 500)) // send fails
-      .mockReturnValueOnce(jsonResponse(null)) // delete campaign (cleanup)
 
     const result = await testListmonkConnection()
 
     expect(result.success).toBe(false)
-    expect(result.steps).toHaveLength(4)
+    expect(result.campaignId).toBe(99)
+    expect(result.steps).toHaveLength(3)
     expect(result.steps[0].status).toBe("ok")
     expect(result.steps[1].status).toBe("ok")
     expect(result.steps[2].status).toBe("error")
-    expect(result.steps[3].status).toBe("ok")
-    expect(mockFetch).toHaveBeenCalledTimes(4)
-  })
-
-  it("should return error at step 4 when cleanup fails", async () => {
-    const { testListmonkConnection } = await import(
-      "./test-listmonk-connection.server"
-    )
-
-    mockFetch
-      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
-      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign ok
-      .mockReturnValueOnce(jsonResponse({ data: {} })) // send ok
-      .mockReturnValueOnce(jsonResponse({ error: "not found" }, 404)) // delete fails
-
-    const result = await testListmonkConnection()
-
-    expect(result.success).toBe(false)
-    expect(result.steps).toHaveLength(4)
-    expect(result.steps[0].status).toBe("ok")
-    expect(result.steps[1].status).toBe("ok")
-    expect(result.steps[2].status).toBe("ok")
-    expect(result.steps[3].status).toBe("error")
   })
 
   it("should have step labels in Portuguese", async () => {
@@ -135,13 +114,49 @@ describe("testListmonkConnection", () => {
       .mockReturnValueOnce(jsonResponse({ data: [] }))
       .mockReturnValueOnce(jsonResponse({ data: { id: 99 } }))
       .mockReturnValueOnce(jsonResponse({ data: {} }))
-      .mockReturnValueOnce(jsonResponse(null))
 
     const result = await testListmonkConnection()
 
     expect(result.steps[0].label).toBe("Conexão estabelecida")
     expect(result.steps[1].label).toBe("Campanha de teste criada")
-    expect(result.steps[2].label).toBe("Email enviado para admins")
-    expect(result.steps[3].label).toBe("Campanha de teste removida")
+    expect(result.steps[2].label).toBe("Email enviado para devs")
+  })
+})
+
+describe("cleanupListmonkTestCampaign", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should delete campaign and return success", async () => {
+    const { cleanupListmonkTestCampaign } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch.mockReturnValueOnce(jsonResponse(null))
+
+    const result = await cleanupListmonkTestCampaign(99)
+
+    expect(result.success).toBe(true)
+    expect(result.step.status).toBe("ok")
+    expect(result.step.label).toBe("Campanha de teste removida")
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://listmonk:9000/api/campaigns/99",
+      expect.objectContaining({ method: "DELETE" }),
+    )
+  })
+
+  it("should return error when delete fails", async () => {
+    const { cleanupListmonkTestCampaign } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch.mockReturnValueOnce(jsonResponse({ error: "not found" }, 404))
+
+    const result = await cleanupListmonkTestCampaign(99)
+
+    expect(result.success).toBe(false)
+    expect(result.step.status).toBe("error")
+    expect(result.step.error).toBeDefined()
   })
 })

--- a/app/business/newsletter/test-listmonk-connection.server.test.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: { error: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock("./listmonk-client.server", () => ({
+  getListmonkConfig: vi.fn(() => ({
+    listmonkApiUrl: "http://listmonk:9000",
+    headers: {
+      Authorization: "Basic dGVzdDp0ZXN0",
+      "Content-Type": "application/json",
+    },
+  })),
+}))
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  })
+}
+
+describe("testListmonkConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should return all 4 steps as ok on full success", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign
+      .mockReturnValueOnce(jsonResponse({ data: {} })) // send (status running)
+      .mockReturnValueOnce(jsonResponse(null)) // delete campaign
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(true)
+    expect(result.steps).toHaveLength(4)
+    expect(result.steps.every((s) => s.status === "ok")).toBe(true)
+  })
+
+  it("should return error at step 1 when connection fails", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch.mockReturnValueOnce(Promise.reject(new Error("fetch failed")))
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(false)
+    expect(result.steps).toHaveLength(1)
+    expect(result.steps[0].status).toBe("error")
+    expect(result.steps[0].error).toContain("fetch failed")
+  })
+
+  it("should return error at step 2 when campaign creation fails, no cleanup needed", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
+      .mockReturnValueOnce(jsonResponse({ error: "bad request" }, 400)) // createCampaign fails
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(false)
+    expect(result.steps).toHaveLength(2)
+    expect(result.steps[0].status).toBe("ok")
+    expect(result.steps[1].status).toBe("error")
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("should return error at step 3 when send fails, still runs cleanup", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign ok
+      .mockReturnValueOnce(jsonResponse({ error: "timeout" }, 500)) // send fails
+      .mockReturnValueOnce(jsonResponse(null)) // delete campaign (cleanup)
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(false)
+    expect(result.steps).toHaveLength(4)
+    expect(result.steps[0].status).toBe("ok")
+    expect(result.steps[1].status).toBe("ok")
+    expect(result.steps[2].status).toBe("error")
+    expect(result.steps[3].status).toBe("ok")
+    expect(mockFetch).toHaveBeenCalledTimes(4)
+  })
+
+  it("should return error at step 4 when cleanup fails", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch
+      .mockReturnValueOnce(jsonResponse({ data: [] })) // testConnection ok
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } })) // createCampaign ok
+      .mockReturnValueOnce(jsonResponse({ data: {} })) // send ok
+      .mockReturnValueOnce(jsonResponse({ error: "not found" }, 404)) // delete fails
+
+    const result = await testListmonkConnection()
+
+    expect(result.success).toBe(false)
+    expect(result.steps).toHaveLength(4)
+    expect(result.steps[0].status).toBe("ok")
+    expect(result.steps[1].status).toBe("ok")
+    expect(result.steps[2].status).toBe("ok")
+    expect(result.steps[3].status).toBe("error")
+  })
+
+  it("should have step labels in Portuguese", async () => {
+    const { testListmonkConnection } = await import(
+      "./test-listmonk-connection.server"
+    )
+
+    mockFetch
+      .mockReturnValueOnce(jsonResponse({ data: [] }))
+      .mockReturnValueOnce(jsonResponse({ data: { id: 99 } }))
+      .mockReturnValueOnce(jsonResponse({ data: {} }))
+      .mockReturnValueOnce(jsonResponse(null))
+
+    const result = await testListmonkConnection()
+
+    expect(result.steps[0].label).toBe("Conexão estabelecida")
+    expect(result.steps[1].label).toBe("Campanha de teste criada")
+    expect(result.steps[2].label).toBe("Email enviado para admins")
+    expect(result.steps[3].label).toBe("Campanha de teste removida")
+  })
+})

--- a/app/business/newsletter/test-listmonk-connection.server.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.ts
@@ -1,22 +1,13 @@
 import { LISTMONK_DEVELOPERS_LIST_ID } from "~/lib/constants/constants"
 import { logger } from "~/lib/logger/logger.server"
 import { getListmonkConfig } from "./listmonk-client.server"
+import type { CleanupResult, DiagnosticResult } from "./test-listmonk-connection.types"
 
-type DiagnosticStep = {
-  label: string
-  status: "ok" | "error"
-  error?: string
-}
-
-export type DiagnosticResult = {
-  success: boolean
-  steps: DiagnosticStep[]
-}
+export type { CleanupResult, DiagnosticResult } from "./test-listmonk-connection.types"
 
 export async function testListmonkConnection(): Promise<DiagnosticResult> {
-  const steps: DiagnosticStep[] = []
+  const steps: DiagnosticResult["steps"] = []
   let campaignId: number | null = null
-  let failed = false
 
   const { listmonkApiUrl, headers } = getListmonkConfig()
 
@@ -36,7 +27,7 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
       status: "error",
       error: message,
     })
-    return { success: false, steps }
+    return { success: false, campaignId: null, steps }
   }
 
   // Step 2: Create test campaign
@@ -69,7 +60,7 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
       status: "error",
       error: message,
     })
-    return { success: false, steps }
+    return { success: false, campaignId: null, steps }
   }
 
   // Step 3: Send campaign
@@ -88,18 +79,26 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
         .catch(() => "Unable to read error body")
       throw new Error(`${response.status}: ${errorBody}`)
     }
-    steps.push({ label: "Email enviado para admins", status: "ok" })
+    steps.push({ label: "Email enviado para devs", status: "ok" })
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error"
     steps.push({
-      label: "Email enviado para admins",
+      label: "Email enviado para devs",
       status: "error",
       error: message,
     })
-    failed = true
+    logger.error("Listmonk diagnostic test failed at send step", { steps })
+    return { success: false, campaignId, steps }
   }
 
-  // Step 4: Cleanup — always runs if campaign was created
+  return { success: true, campaignId, steps }
+}
+
+export async function cleanupListmonkTestCampaign(
+  campaignId: number,
+): Promise<CleanupResult> {
+  const { listmonkApiUrl, headers } = getListmonkConfig()
+
   try {
     const response = await fetch(
       `${listmonkApiUrl}/api/campaigns/${campaignId}`,
@@ -114,20 +113,23 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
         .catch(() => "Unable to read error body")
       throw new Error(`${response.status}: ${errorBody}`)
     }
-    steps.push({ label: "Campanha de teste removida", status: "ok" })
+    return {
+      success: true,
+      step: { label: "Campanha de teste removida", status: "ok" },
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error"
-    steps.push({
-      label: "Campanha de teste removida",
-      status: "error",
+    logger.error("Listmonk diagnostic cleanup failed", {
+      campaignId,
       error: message,
     })
-    failed = true
+    return {
+      success: false,
+      step: {
+        label: "Campanha de teste removida",
+        status: "error",
+        error: message,
+      },
+    }
   }
-
-  if (failed) {
-    logger.error("Listmonk diagnostic test failed", { steps })
-  }
-
-  return { success: !failed, steps }
 }

--- a/app/business/newsletter/test-listmonk-connection.server.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.ts
@@ -9,7 +9,21 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
   const steps: DiagnosticResult["steps"] = []
   let campaignId: number | null = null
 
-  const { listmonkApiUrl, headers } = getListmonkConfig()
+  let listmonkApiUrl: string
+  let headers: Record<string, string>
+  try {
+    const config = getListmonkConfig()
+    listmonkApiUrl = config.listmonkApiUrl
+    headers = config.headers
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    steps.push({
+      label: "Configuração do Listmonk",
+      status: "error",
+      error: message,
+    })
+    return { success: false, campaignId: null, steps }
+  }
 
   // Step 1: Test connection
   try {
@@ -97,7 +111,27 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
 export async function cleanupListmonkTestCampaign(
   campaignId: number,
 ): Promise<CleanupResult> {
-  const { listmonkApiUrl, headers } = getListmonkConfig()
+  let listmonkApiUrl: string
+  let headers: Record<string, string>
+  try {
+    const config = getListmonkConfig()
+    listmonkApiUrl = config.listmonkApiUrl
+    headers = config.headers
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    logger.error("Listmonk diagnostic cleanup failed - config error", {
+      campaignId,
+      error: message,
+    })
+    return {
+      success: false,
+      step: {
+        label: "Campanha de teste removida",
+        status: "error",
+        error: message,
+      },
+    }
+  }
 
   try {
     const response = await fetch(

--- a/app/business/newsletter/test-listmonk-connection.server.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.ts
@@ -1,4 +1,4 @@
-import { LISTMONK_ADMIN_LIST_ID } from "~/lib/constants/constants"
+import { LISTMONK_DEVELOPERS_LIST_ID } from "~/lib/constants/constants"
 import { logger } from "~/lib/logger/logger.server"
 import { getListmonkConfig } from "./listmonk-client.server"
 
@@ -47,7 +47,7 @@ export async function testListmonkConnection(): Promise<DiagnosticResult> {
       body: JSON.stringify({
         name: `[TESTE] Diagnóstico de conexão - ${new Date().toISOString()}`,
         subject: "[TESTE] Diagnóstico de conexão com Listmonk",
-        lists: [LISTMONK_ADMIN_LIST_ID],
+        lists: [LISTMONK_DEVELOPERS_LIST_ID],
         type: "regular",
         content_type: "html",
         body: "<p>Este é um email de teste enviado pelo diagnóstico de conexão do painel admin.</p>",

--- a/app/business/newsletter/test-listmonk-connection.server.ts
+++ b/app/business/newsletter/test-listmonk-connection.server.ts
@@ -1,0 +1,133 @@
+import { LISTMONK_ADMIN_LIST_ID } from "~/lib/constants/constants"
+import { logger } from "~/lib/logger/logger.server"
+import { getListmonkConfig } from "./listmonk-client.server"
+
+type DiagnosticStep = {
+  label: string
+  status: "ok" | "error"
+  error?: string
+}
+
+export type DiagnosticResult = {
+  success: boolean
+  steps: DiagnosticStep[]
+}
+
+export async function testListmonkConnection(): Promise<DiagnosticResult> {
+  const steps: DiagnosticStep[] = []
+  let campaignId: number | null = null
+  let failed = false
+
+  const { listmonkApiUrl, headers } = getListmonkConfig()
+
+  // Step 1: Test connection
+  try {
+    const response = await fetch(`${listmonkApiUrl}/api/subscribers`, {
+      headers,
+    })
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`)
+    }
+    steps.push({ label: "Conexão estabelecida", status: "ok" })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    steps.push({
+      label: "Conexão estabelecida",
+      status: "error",
+      error: message,
+    })
+    return { success: false, steps }
+  }
+
+  // Step 2: Create test campaign
+  try {
+    const response = await fetch(`${listmonkApiUrl}/api/campaigns`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: `[TESTE] Diagnóstico de conexão - ${new Date().toISOString()}`,
+        subject: "[TESTE] Diagnóstico de conexão com Listmonk",
+        lists: [LISTMONK_ADMIN_LIST_ID],
+        type: "regular",
+        content_type: "html",
+        body: "<p>Este é um email de teste enviado pelo diagnóstico de conexão do painel admin.</p>",
+      }),
+    })
+    if (!response.ok) {
+      const errorBody = await response
+        .text()
+        .catch(() => "Unable to read error body")
+      throw new Error(`${response.status}: ${errorBody}`)
+    }
+    const result = (await response.json()) as { data: { id: number } }
+    campaignId = result.data.id
+    steps.push({ label: "Campanha de teste criada", status: "ok" })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    steps.push({
+      label: "Campanha de teste criada",
+      status: "error",
+      error: message,
+    })
+    return { success: false, steps }
+  }
+
+  // Step 3: Send campaign
+  try {
+    const response = await fetch(
+      `${listmonkApiUrl}/api/campaigns/${campaignId}/status`,
+      {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ status: "running" }),
+      },
+    )
+    if (!response.ok) {
+      const errorBody = await response
+        .text()
+        .catch(() => "Unable to read error body")
+      throw new Error(`${response.status}: ${errorBody}`)
+    }
+    steps.push({ label: "Email enviado para admins", status: "ok" })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    steps.push({
+      label: "Email enviado para admins",
+      status: "error",
+      error: message,
+    })
+    failed = true
+  }
+
+  // Step 4: Cleanup — always runs if campaign was created
+  try {
+    const response = await fetch(
+      `${listmonkApiUrl}/api/campaigns/${campaignId}`,
+      {
+        method: "DELETE",
+        headers,
+      },
+    )
+    if (!response.ok) {
+      const errorBody = await response
+        .text()
+        .catch(() => "Unable to read error body")
+      throw new Error(`${response.status}: ${errorBody}`)
+    }
+    steps.push({ label: "Campanha de teste removida", status: "ok" })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    steps.push({
+      label: "Campanha de teste removida",
+      status: "error",
+      error: message,
+    })
+    failed = true
+  }
+
+  if (failed) {
+    logger.error("Listmonk diagnostic test failed", { steps })
+  }
+
+  return { success: !failed, steps }
+}

--- a/app/business/newsletter/test-listmonk-connection.types.ts
+++ b/app/business/newsletter/test-listmonk-connection.types.ts
@@ -1,0 +1,16 @@
+export type DiagnosticStep = {
+  label: string
+  status: "ok" | "error"
+  error?: string
+}
+
+export type DiagnosticResult = {
+  success: boolean
+  campaignId: number | null
+  steps: DiagnosticStep[]
+}
+
+export type CleanupResult = {
+  success: boolean
+  step: DiagnosticStep
+}

--- a/app/components/pages/admin/listmonk-diagnostic-section.test.tsx
+++ b/app/components/pages/admin/listmonk-diagnostic-section.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createMemoryRouter, RouterProvider } from "react-router"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const createMockFetcher = (
+  overrides?: Partial<{
+    state: "idle" | "submitting" | "loading"
+    data: unknown
+  }>,
+) => ({
+  submit: vi.fn(),
+  state: overrides?.state ?? ("idle" as const),
+  formData: undefined,
+  data: overrides?.data ?? undefined,
+  formAction: undefined,
+  formMethod: undefined,
+  formEncType: undefined,
+  text: undefined,
+  json: undefined,
+  key: "",
+  Form: () => null,
+  load: vi.fn(),
+})
+
+let mockFetcher = createMockFetcher()
+
+vi.mock("react-router", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-router")>()
+  return {
+    ...original,
+    useFetcher: () => mockFetcher,
+  }
+})
+
+function renderWithRouter(element: React.ReactElement) {
+  const router = createMemoryRouter(
+    [{ path: "/", element }],
+    { initialEntries: ["/"] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+describe("ListmonkDiagnosticSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetcher = createMockFetcher()
+  })
+
+  it("should render section title and description", async () => {
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    expect(
+      screen.getByRole("heading", { name: /diagnóstico de email/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/testa a conexão com o serviço de newsletter/i),
+    ).toBeInTheDocument()
+  })
+
+  it("should render test button", async () => {
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    expect(
+      screen.getByRole("button", { name: /testar conexão com listmonk/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("should show loading state when fetcher is submitting", async () => {
+    mockFetcher = createMockFetcher({ state: "submitting" })
+
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    expect(screen.getByText(/testando/i)).toBeInTheDocument()
+  })
+
+  it("should open confirm dialog when button is clicked", async () => {
+    const user = userEvent.setup()
+
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    await user.click(
+      screen.getByRole("button", { name: /testar conexão com listmonk/i }),
+    )
+
+    expect(
+      screen.getByText(/será enviado um email de teste/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/app/components/pages/admin/listmonk-diagnostic-section.test.tsx
+++ b/app/components/pages/admin/listmonk-diagnostic-section.test.tsx
@@ -10,12 +10,12 @@ vi.mock("sonner", () => ({
   },
 }))
 
-const createMockFetcher = (
-  overrides?: Partial<{
-    state: "idle" | "submitting" | "loading"
-    data: unknown
-  }>,
-) => ({
+type FetcherOverrides = Partial<{
+  state: "idle" | "submitting" | "loading"
+  data: unknown
+}>
+
+const createMockFetcher = (overrides?: FetcherOverrides) => ({
   submit: vi.fn(),
   state: overrides?.state ?? ("idle" as const),
   formData: undefined,
@@ -30,13 +30,23 @@ const createMockFetcher = (
   load: vi.fn(),
 })
 
-let mockFetcher = createMockFetcher()
+let fetcherConfigs: [FetcherOverrides | undefined, FetcherOverrides | undefined] = [
+  undefined,
+  undefined,
+]
 
 vi.mock("react-router", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-router")>()
   return {
     ...original,
-    useFetcher: () => mockFetcher,
+    useFetcher: (() => {
+      let instanceIndex = 0
+      return () => {
+        const index = instanceIndex
+        instanceIndex = (instanceIndex + 1) % 2
+        return createMockFetcher(fetcherConfigs[index])
+      }
+    })(),
   }
 })
 
@@ -51,7 +61,7 @@ function renderWithRouter(element: React.ReactElement) {
 describe("ListmonkDiagnosticSection", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFetcher = createMockFetcher()
+    fetcherConfigs = [undefined, undefined]
   })
 
   it("should render section title and description", async () => {
@@ -69,7 +79,7 @@ describe("ListmonkDiagnosticSection", () => {
     ).toBeInTheDocument()
   })
 
-  it("should render test button", async () => {
+  it("should render test button but not cleanup button initially", async () => {
     const { ListmonkDiagnosticSection } = await import(
       "./listmonk-diagnostic-section"
     )
@@ -79,10 +89,13 @@ describe("ListmonkDiagnosticSection", () => {
     expect(
       screen.getByRole("button", { name: /testar conexão com listmonk/i }),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /limpar campanha/i }),
+    ).not.toBeInTheDocument()
   })
 
-  it("should show loading state when fetcher is submitting", async () => {
-    mockFetcher = createMockFetcher({ state: "submitting" })
+  it("should show loading state when test fetcher is submitting", async () => {
+    fetcherConfigs = [{ state: "submitting" }, undefined]
 
     const { ListmonkDiagnosticSection } = await import(
       "./listmonk-diagnostic-section"
@@ -93,7 +106,7 @@ describe("ListmonkDiagnosticSection", () => {
     expect(screen.getByText(/testando/i)).toBeInTheDocument()
   })
 
-  it("should open confirm dialog when button is clicked", async () => {
+  it("should open confirm dialog when test button is clicked", async () => {
     const user = userEvent.setup()
 
     const { ListmonkDiagnosticSection } = await import(
@@ -109,5 +122,63 @@ describe("ListmonkDiagnosticSection", () => {
     expect(
       screen.getByText(/será enviado um email de teste/i),
     ).toBeInTheDocument()
+  })
+
+  it("should show cleanup button after successful test with campaignId", async () => {
+    fetcherConfigs = [
+      {
+        data: {
+          intent: "test-listmonk",
+          diagnosticResult: {
+            success: true,
+            campaignId: 99,
+            steps: [
+              { label: "Conexão estabelecida", status: "ok" },
+              { label: "Campanha de teste criada", status: "ok" },
+              { label: "Email enviado para devs", status: "ok" },
+            ],
+          },
+        },
+      },
+      undefined,
+    ]
+
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    expect(
+      screen.getByRole("button", { name: /limpar campanha/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("should not show cleanup button after failed test with no campaignId", async () => {
+    fetcherConfigs = [
+      {
+        data: {
+          intent: "test-listmonk",
+          diagnosticResult: {
+            success: false,
+            campaignId: null,
+            steps: [
+              { label: "Conexão estabelecida", status: "error", error: "fail" },
+            ],
+          },
+        },
+      },
+      undefined,
+    ]
+
+    const { ListmonkDiagnosticSection } = await import(
+      "./listmonk-diagnostic-section"
+    )
+
+    renderWithRouter(<ListmonkDiagnosticSection />)
+
+    expect(
+      screen.queryByRole("button", { name: /limpar campanha/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/components/pages/admin/listmonk-diagnostic-section.tsx
+++ b/app/components/pages/admin/listmonk-diagnostic-section.tsx
@@ -2,56 +2,105 @@ import { useEffect, useState } from "react"
 import { useFetcher } from "react-router"
 import { toast } from "sonner"
 import ConfirmDialog from "~/components/molecules/confirm-dialog/confirm-dialog"
-import type { DiagnosticResult } from "~/business/newsletter/test-listmonk-connection.server"
+import { Button } from "~/components/ui/button"
+import type {
+  CleanupResult,
+  DiagnosticResult,
+} from "~/business/newsletter/test-listmonk-connection.types"
 
-type FetcherData = {
+type TestFetcherData = {
   intent?: string
   diagnosticResult?: DiagnosticResult
 }
 
-export function ListmonkDiagnosticSection() {
-  const fetcher = useFetcher<FetcherData>()
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const isSubmitting =
-    fetcher.state === "submitting" || fetcher.state === "loading"
+type CleanupFetcherData = {
+  intent?: string
+  cleanupResult?: CleanupResult
+}
 
-  const handleConfirm = async (closeDialog: () => void) => {
+export function ListmonkDiagnosticSection() {
+  const testFetcher = useFetcher<TestFetcherData>()
+  const cleanupFetcher = useFetcher<CleanupFetcherData>()
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [campaignId, setCampaignId] = useState<number | null>(null)
+
+  const isTestSubmitting =
+    testFetcher.state === "submitting" || testFetcher.state === "loading"
+  const isCleanupSubmitting =
+    cleanupFetcher.state === "submitting" || cleanupFetcher.state === "loading"
+
+  const handleTestConfirm = async (closeDialog: () => void) => {
+    setCampaignId(null)
     const formData = new FormData()
     formData.append("intent", "test-listmonk")
-    fetcher.submit(formData, { method: "POST" })
+    testFetcher.submit(formData, { method: "POST" })
     closeDialog()
   }
 
-  useEffect(() => {
-    if (fetcher.data?.intent !== "test-listmonk" || !fetcher.data.diagnosticResult) return
+  const handleCleanup = () => {
+    if (!campaignId) return
+    const formData = new FormData()
+    formData.append("intent", "cleanup-listmonk")
+    formData.append("campaignId", String(campaignId))
+    cleanupFetcher.submit(formData, { method: "POST" })
+  }
 
-    const { success, steps } = fetcher.data.diagnosticResult
-    const stepsText = steps
-      .map((s) =>
-        s.status === "ok"
-          ? `✓ ${s.label}`
-          : `✗ ${s.label}${s.error ? `: ${s.error}` : ""}`,
-      )
-      .join("\n")
+  useEffect(() => {
+    if (
+      testFetcher.data?.intent !== "test-listmonk" ||
+      !testFetcher.data.diagnosticResult
+    )
+      return
+
+    const { success, steps, campaignId: resultCampaignId } =
+      testFetcher.data.diagnosticResult
+
+    if (resultCampaignId) {
+      setCampaignId(resultCampaignId)
+    }
+
+    steps.forEach((step, index) => {
+      const delay = index * 800
+      setTimeout(() => {
+        if (step.status === "ok") {
+          toast.success(`✓ ${step.label}`, { duration: 6000 })
+        } else {
+          toast.error(`✗ ${step.label}`, {
+            description: step.error,
+            duration: 12000,
+          })
+        }
+      }, delay)
+    })
+
+    if (!success && !resultCampaignId) {
+      setTimeout(() => {
+        toast.error("Diagnóstico falhou antes de criar a campanha", {
+          duration: 8000,
+        })
+      }, steps.length * 800)
+    }
+  }, [testFetcher.data])
+
+  useEffect(() => {
+    if (
+      cleanupFetcher.data?.intent !== "cleanup-listmonk" ||
+      !cleanupFetcher.data.cleanupResult
+    )
+      return
+
+    const { success, step } = cleanupFetcher.data.cleanupResult
 
     if (success) {
-      toast.success("Conexão com Listmonk OK!", {
-        description: stepsText,
-        duration: 8000,
-      })
+      toast.success(`✓ ${step.label}`, { duration: 6000 })
+      setCampaignId(null)
     } else {
-      const firstError = steps.find((s) => s.status === "error")
-      toast.error(
-        firstError?.error
-          ? `${firstError.label}: ${firstError.error}`
-          : "Falha no diagnóstico",
-        {
-          description: stepsText,
-          duration: 12000,
-        },
-      )
+      toast.error(`✗ ${step.label}`, {
+        description: step.error,
+        duration: 12000,
+      })
     }
-  }, [fetcher.data])
+  }, [cleanupFetcher.data])
 
   return (
     <div className="flex flex-col gap-4">
@@ -60,14 +109,14 @@ export function ListmonkDiagnosticSection() {
           <h2>Diagnóstico de Email</h2>
           <p className="text-sm text-muted-foreground">
             Essa ferramenta testa a conexão com o serviço de newsletter
-            (Listmonk) e envia uma campanha de teste para os administradores.
+            (Listmonk) e envia uma campanha de teste para os desenvolvedores.
             Use quando quiser verificar se os emails de abertura de evento estão
             funcionando.
           </p>
         </div>
       </div>
 
-      <div>
+      <div className="flex gap-2">
         <ConfirmDialog
           title="Testar conexão?"
           description="Será enviado um email de teste para todos os desenvolvedores cadastrados na lista de devs do Listmonk."
@@ -75,16 +124,29 @@ export function ListmonkDiagnosticSection() {
           cancelLabel="Cancelar"
           open={isDialogOpen}
           onOpenChange={setIsDialogOpen}
-          isLoading={isSubmitting}
-          onConfirm={handleConfirm}
+          isLoading={isTestSubmitting}
+          onConfirm={handleTestConfirm}
         >
           <ConfirmDialog.Trigger
             variant="outline"
-            disabled={isSubmitting}
+            disabled={isTestSubmitting}
           >
-            {isSubmitting ? "Testando..." : "Testar conexão com Listmonk"}
+            {isTestSubmitting ? "Testando..." : "Testar conexão com Listmonk"}
           </ConfirmDialog.Trigger>
         </ConfirmDialog>
+
+        {campaignId && (
+          <Button
+            variant="destructive"
+            size="default"
+            onClick={handleCleanup}
+            disabled={isCleanupSubmitting}
+          >
+            {isCleanupSubmitting
+              ? "Limpando..."
+              : "Limpar campanha de teste"}
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/app/components/pages/admin/listmonk-diagnostic-section.tsx
+++ b/app/components/pages/admin/listmonk-diagnostic-section.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react"
+import { useFetcher } from "react-router"
+import { toast } from "sonner"
+import ConfirmDialog from "~/components/molecules/confirm-dialog/confirm-dialog"
+import type { DiagnosticResult } from "~/business/newsletter/test-listmonk-connection.server"
+
+type FetcherData = {
+  intent?: string
+  diagnosticResult?: DiagnosticResult
+}
+
+export function ListmonkDiagnosticSection() {
+  const fetcher = useFetcher<FetcherData>()
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const isSubmitting =
+    fetcher.state === "submitting" || fetcher.state === "loading"
+
+  const handleConfirm = async (closeDialog: () => void) => {
+    const formData = new FormData()
+    formData.append("intent", "test-listmonk")
+    fetcher.submit(formData, { method: "POST" })
+    closeDialog()
+  }
+
+  useEffect(() => {
+    if (fetcher.data?.intent !== "test-listmonk" || !fetcher.data.diagnosticResult) return
+
+    const { success, steps } = fetcher.data.diagnosticResult
+    const stepsText = steps
+      .map((s) =>
+        s.status === "ok"
+          ? `✓ ${s.label}`
+          : `✗ ${s.label}${s.error ? `: ${s.error}` : ""}`,
+      )
+      .join("\n")
+
+    if (success) {
+      toast.success("Conexão com Listmonk OK!", {
+        description: stepsText,
+        duration: 8000,
+      })
+    } else {
+      const firstError = steps.find((s) => s.status === "error")
+      toast.error(
+        firstError?.error
+          ? `${firstError.label}: ${firstError.error}`
+          : "Falha no diagnóstico",
+        {
+          description: stepsText,
+          duration: 12000,
+        },
+      )
+    }
+  }, [fetcher.data])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h2>Diagnóstico de Email</h2>
+          <p className="text-sm text-muted-foreground">
+            Essa ferramenta testa a conexão com o serviço de newsletter
+            (Listmonk) e envia uma campanha de teste para os administradores.
+            Use quando quiser verificar se os emails de abertura de evento estão
+            funcionando.
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <ConfirmDialog
+          title="Testar conexão?"
+          description="Será enviado um email de teste para todos os administradores cadastrados na lista de admins do Listmonk."
+          confirmLabel="Testar"
+          cancelLabel="Cancelar"
+          open={isDialogOpen}
+          onOpenChange={setIsDialogOpen}
+          isLoading={isSubmitting}
+          onConfirm={handleConfirm}
+        >
+          <ConfirmDialog.Trigger
+            variant="outline"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Testando..." : "Testar conexão com Listmonk"}
+          </ConfirmDialog.Trigger>
+        </ConfirmDialog>
+      </div>
+    </div>
+  )
+}

--- a/app/components/pages/admin/listmonk-diagnostic-section.tsx
+++ b/app/components/pages/admin/listmonk-diagnostic-section.tsx
@@ -70,7 +70,7 @@ export function ListmonkDiagnosticSection() {
       <div>
         <ConfirmDialog
           title="Testar conexão?"
-          description="Será enviado um email de teste para todos os administradores cadastrados na lista de admins do Listmonk."
+          description="Será enviado um email de teste para todos os desenvolvedores cadastrados na lista de devs do Listmonk."
           confirmLabel="Testar"
           cancelLabel="Cancelar"
           open={isDialogOpen}

--- a/app/lib/constants/constants.ts
+++ b/app/lib/constants/constants.ts
@@ -47,7 +47,7 @@ export const RACE_COLOR = [
 
 export const LISTMONK_REGISTERED_LIST_ID = 4
 export const LISTMONK_TEST_LIST_ID = 5
-export const LISTMONK_ADMIN_LIST_ID = 16
+export const LISTMONK_DEVELOPERS_LIST_ID = 16
 
 // Event Opened Template
 export const LISTMONK_EVENT_OPENING_TEMPLATE_ID = 7

--- a/app/lib/constants/constants.ts
+++ b/app/lib/constants/constants.ts
@@ -47,6 +47,7 @@ export const RACE_COLOR = [
 
 export const LISTMONK_REGISTERED_LIST_ID = 4
 export const LISTMONK_TEST_LIST_ID = 5
+export const LISTMONK_ADMIN_LIST_ID = 16
 
 // Event Opened Template
 export const LISTMONK_EVENT_OPENING_TEMPLATE_ID = 7

--- a/app/pages/admin/dashboard/dashboard-page.component.test.tsx
+++ b/app/pages/admin/dashboard/dashboard-page.component.test.tsx
@@ -36,6 +36,12 @@ vi.mock("~/components/organisms/tables/admin/recent-feedbacks-table", () => ({
   RecentFeedbacksTable: () => <div data-testid="recent-feedbacks-table" />,
 }))
 
+vi.mock("~/components/pages/admin/listmonk-diagnostic-section", () => ({
+  ListmonkDiagnosticSection: () => (
+    <div data-testid="listmonk-diagnostic-section" />
+  ),
+}))
+
 vi.mock("~/components/ui/button", () => ({
   Button: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
     <button>{children}</button>

--- a/app/pages/admin/dashboard/dashboard-page.tsx
+++ b/app/pages/admin/dashboard/dashboard-page.tsx
@@ -4,7 +4,10 @@ import {
   getRecentProfiles,
 } from "~/business/admin/admin.server"
 import { getRecentFeedbacks } from "~/business/feedback/feedback.server"
-import { testListmonkConnection } from "~/business/newsletter/test-listmonk-connection.server"
+import {
+  cleanupListmonkTestCampaign,
+  testListmonkConnection,
+} from "~/business/newsletter/test-listmonk-connection.server"
 import { EventCard } from "~/components/organisms/event-card/event-card"
 import { AdminDashboardEventsTable } from "~/components/organisms/tables/admin/events-table"
 import { RecentFeedbacksTable } from "~/components/organisms/tables/admin/recent-feedbacks-table"
@@ -31,6 +34,12 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "test-listmonk") {
     const diagnosticResult = await testListmonkConnection()
     return { intent: "test-listmonk", diagnosticResult }
+  }
+
+  if (intent === "cleanup-listmonk") {
+    const campaignId = Number(formData.get("campaignId"))
+    const cleanupResult = await cleanupListmonkTestCampaign(campaignId)
+    return { intent: "cleanup-listmonk", cleanupResult }
   }
 
   return { intent }

--- a/app/pages/admin/dashboard/dashboard-page.tsx
+++ b/app/pages/admin/dashboard/dashboard-page.tsx
@@ -4,10 +4,12 @@ import {
   getRecentProfiles,
 } from "~/business/admin/admin.server"
 import { getRecentFeedbacks } from "~/business/feedback/feedback.server"
+import { testListmonkConnection } from "~/business/newsletter/test-listmonk-connection.server"
 import { EventCard } from "~/components/organisms/event-card/event-card"
 import { AdminDashboardEventsTable } from "~/components/organisms/tables/admin/events-table"
 import { RecentFeedbacksTable } from "~/components/organisms/tables/admin/recent-feedbacks-table"
 import { RecentProfilesTable } from "~/components/organisms/tables/admin/recent-profiles-table"
+import { ListmonkDiagnosticSection } from "~/components/pages/admin/listmonk-diagnostic-section"
 import { Button } from "~/components/ui/button"
 import { Separator } from "~/components/ui/separator"
 import { createMetaArray } from "~/lib/helpers/meta"
@@ -20,6 +22,18 @@ const {
 
 export function meta({}: Route.MetaArgs) {
   return createMetaArray("Admin - Visão Geral")
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData()
+  const intent = formData.get("intent")
+
+  if (intent === "test-listmonk") {
+    const diagnosticResult = await testListmonkConnection()
+    return { intent: "test-listmonk", diagnosticResult }
+  }
+
+  return { intent }
 }
 
 export async function loader() {
@@ -100,6 +114,10 @@ const AdminDashboard = ({ loaderData }: Route.ComponentProps) => {
 
         <RecentFeedbacksTable feedbacks={recentFeedbacks} />
       </div>
+
+      <Separator />
+
+      <ListmonkDiagnosticSection />
 
       <Separator />
 


### PR DESCRIPTION
## Linear Ticket

Fixes POS-474

## Summary

- Adds a "Diagnóstico de Email" section to the admin dashboard that tests the Listmonk connection end-to-end: ping, create test campaign, and send to the developers list
- Separates test and cleanup into two distinct actions so admins can inspect the campaign in Listmonk before deleting it
- Shows sequential toasts for each step instead of a single combined toast

## How to test manually

1. Log in as admin → Admin Dashboard → scroll to "Diagnóstico de Email"
2. Click "Testar conexão com Listmonk" → confirm dialog → 3 sequential green toasts appear
3. A red "Limpar campanha de teste" button appears after success
4. Check Listmonk admin — test campaign exists; check inbox — test email received
5. Click "Limpar campanha de teste" → campaign deleted, button disappears
6. To test failure: break LISTMONK_API_URL → red error toast, no cleanup button

## Implementation Notes

- Types extracted to `.types.ts` to avoid server-only import on client side (React Router constraint)
- Uses `LISTMONK_DEVELOPERS_LIST_ID` (ID 16) — sends test emails to the devs list, not admins
- Cleanup is manual so campaigns persist for debugging when emails don't arrive

## Testing

- 7 unit tests for server functions (testListmonkConnection + cleanupListmonkTestCampaign)
- 6 UI tests for the diagnostic section component
- All 168 test files pass (1588 tests), lint clean

## Breaking Changes

None