### PR TITLE
[NO-TICKET] Fix double slash in email dashboard URL

### DIFF
--- a/app/lib/constants/constants.test.ts
+++ b/app/lib/constants/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ORIENTATIONS, POSITIV_WHATSAPP } from './constants'
+import { DASHBOARD_URL, ORIENTATIONS, POSITIV_URL, POSITIV_WHATSAPP } from './constants'
 
 describe('ORIENTATIONS', () => {
   it('should contain Lésbica as an orientation option', () => {
@@ -8,6 +8,16 @@ describe('ORIENTATIONS', () => {
 
   it('should not contain Sapatão as an orientation option', () => {
     expect(ORIENTATIONS).not.toContain('Sapatão')
+  })
+})
+
+describe('URL constants', () => {
+  it('should not contain double slashes in paths', () => {
+    expect(DASHBOARD_URL).not.toMatch(/https?:\/\/[^/]+\/\//)
+  })
+
+  it('DASHBOARD_URL should resolve to the correct URL', () => {
+    expect(DASHBOARD_URL).toBe(`${POSITIV_URL}dashboard`)
   })
 })
 

--- a/app/lib/constants/constants.ts
+++ b/app/lib/constants/constants.ts
@@ -1,5 +1,5 @@
 export const POSITIV_URL = "https://www.positivparty.com/"
-export const DASHBOARD_URL = `${POSITIV_URL}/dashboard`
+export const DASHBOARD_URL = `${POSITIV_URL}dashboard`
 
 export const POSITIV_EMAIL = "contato@positivparty.com"
 


### PR DESCRIPTION
## Linear Ticket

Fixes NO-TICKET

## Summary

- `DASHBOARD_URL` was producing `https://www.positivparty.com//dashboard` because `POSITIV_URL` already ends with `/` and the constant prepended another `/`
- Affects CTA links in event opening emails, pre-opening reminders, and campaign emails

## How to test manually

1. Check the value of `DASHBOARD_URL` in `app/lib/constants/constants.ts` — should be `https://www.positivparty.com/dashboard` (single slash)

## Implementation Notes

One-character fix: removed the leading `/` from the template literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)