### PR TITLE
[NO-TICKET] Fix unfriendly checkbox validation error in rules form

### DIFF
--- a/app/components/forms/custom/rules/rules-form-schema.test.tsx
+++ b/app/components/forms/custom/rules/rules-form-schema.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { zod } from "~/lib/helpers/zod"
+import { getRulesFormSchema } from "./rules-form-schema"
+
+describe("getRulesFormSchema", () => {
+  it("should show 'Resposta obrigatória' when checkbox question receives undefined", () => {
+    const schemaFields = getRulesFormSchema("regular")
+    const schema = zod.object(schemaFields)
+
+    const result = schema.safeParse({})
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).not.toContain("Expected array, received undefined")
+      expect(messages).toContain("Resposta obrigatória")
+    }
+  })
+})

--- a/app/components/forms/custom/rules/rules-form-schema.tsx
+++ b/app/components/forms/custom/rules/rules-form-schema.tsx
@@ -20,7 +20,8 @@ export const getRulesFormSchema = (eventType: EventType) => {
         // Multiple-select (checkbox)
         acc[key] = zod
           .array(zod.string())
-          .min(1, { message: "Resposta obrigatória" })
+          .default([])
+          .pipe(zod.array(zod.string()).min(1, { message: "Resposta obrigatória" }))
           .refine(
             (answers) =>
               answers.some((answer) => question.answers.correct.includes(answer)),


### PR DESCRIPTION
## Linear Ticket

Fixes NO-TICKET

## Summary

- When no checkbox was selected in the rules questions form, users saw the raw Zod error "Tipos incorretos. Esperado: array. Recebido: undefined" instead of the intended "Resposta obrigatória"
- Fixed by using `.default([]).pipe()` so `undefined` becomes `[]` before validation, letting `.min(1)` produce the friendly message

## How to test manually

1. Go to any event application → Rules step
2. Don't check any checkbox on a multi-select question
3. Submit → should see "Resposta obrigatória", **not** "Tipos incorretos..."

## Testing

- Added `rules-form-schema.test.tsx` verifying undefined input produces the correct error message
- All 19 rules-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)