### PR TITLE
[POS-464] Webhook endpoint: timing-safe token + status guards + REFUNDED handler

### DIFF
--- a/app/routes/api.asaas-webhook.test.ts
+++ b/app/routes/api.asaas-webhook.test.ts
@@ -110,6 +110,9 @@ describe("api.asaas-webhook", () => {
     const request = makeRequest({ event: "PAYMENT_RECEIVED", payment: { id: "pay_1", value: 220 } })
     const response = await action(actionArgs(request))
     expect(response.status).toBe(200)
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining("webhook authentication disabled"),
+    )
   })
 
   it("rejects requests with 503 when ASAAS_WEBHOOK_TOKEN is not configured in production", async () => {

--- a/app/routes/api.asaas-webhook.test.ts
+++ b/app/routes/api.asaas-webhook.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockEnv = vi.hoisted(() => ({
+  paymentSystemOnline: true,
+  asaasWebhookToken: "test-webhook-token",
+  nodeEnv: "test" as "development" | "production" | "test",
+}))
+
+const mockSelectResult = vi.hoisted(() => ({ value: undefined as unknown }))
+const mockUpdateResult = vi.hoisted(() => ({ value: undefined as unknown }))
+const mockExecute = vi.hoisted(() => vi.fn().mockResolvedValue([]))
+
+vi.mock("~/env.server", () => ({
+  env: () => mockEnv,
+}))
+
+vi.mock("~/kysely-db", () => {
+  function chainProxy(kind: "select" | "update"): unknown {
+    return new Proxy(
+      {},
+      {
+        get(_, prop) {
+          if (typeof prop === "symbol") return undefined
+          if (prop === "then") return undefined
+          if (prop === "executeTakeFirst") {
+            return () =>
+              Promise.resolve(
+                kind === "select"
+                  ? mockSelectResult.value
+                  : mockUpdateResult.value,
+              )
+          }
+          if (prop === "execute") return mockExecute
+          return () => chainProxy(kind)
+        },
+      },
+    )
+  }
+  return {
+    kyselyDb: {
+      selectFrom: () => chainProxy("select"),
+      updateTable: () => chainProxy("update"),
+    },
+  }
+})
+
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { action } from "./api.asaas-webhook"
+import { logger } from "~/lib/logger/logger.server"
+
+function makeRequest(body: unknown, token?: string) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" }
+  if (token) headers["asaas-access-token"] = token
+  return new Request("http://localhost/api/asaas-webhook", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+const actionArgs = (request: Request) => ({ request, params: {}, context: {} })
+
+describe("api.asaas-webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnv.paymentSystemOnline = true
+    mockEnv.asaasWebhookToken = "test-webhook-token"
+    mockEnv.nodeEnv = "test"
+    mockSelectResult.value = undefined
+    mockUpdateResult.value = undefined
+  })
+
+  it("returns 404 when payment system is offline", async () => {
+    mockEnv.paymentSystemOnline = false
+    const request = makeRequest({ event: "PAYMENT_RECEIVED", payment: { id: "pay_1" } }, "test-webhook-token")
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(404)
+  })
+
+  it("returns 401 when token is missing", async () => {
+    const request = makeRequest({ event: "PAYMENT_RECEIVED", payment: { id: "pay_1" } })
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(401)
+    const json = await response.json()
+    expect(json.error).toContain("token")
+  })
+
+  it("returns 401 when token is invalid", async () => {
+    const request = makeRequest(
+      { event: "PAYMENT_RECEIVED", payment: { id: "pay_1" } },
+      "wrong-token",
+    )
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(401)
+  })
+
+  it("allows requests but logs warning when ASAAS_WEBHOOK_TOKEN is not configured (dev/test)", async () => {
+    mockEnv.asaasWebhookToken = undefined as unknown as string
+    mockEnv.nodeEnv = "development"
+    mockSelectResult.value = {
+      id: "pr-1",
+      event_participant_id: "ep-1",
+      status: "awaiting_payment",
+      amount: 220,
+    }
+
+    const request = makeRequest({ event: "PAYMENT_RECEIVED", payment: { id: "pay_1", value: 220 } })
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(200)
+  })
+
+  it("rejects requests with 503 when ASAAS_WEBHOOK_TOKEN is not configured in production", async () => {
+    mockEnv.asaasWebhookToken = undefined as unknown as string
+    mockEnv.nodeEnv = "production"
+
+    const request = makeRequest({ event: "PAYMENT_RECEIVED", payment: { id: "pay_1", value: 220 } })
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(503)
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining("not configured in production"),
+    )
+  })
+
+  it("returns 200 and logs warning for unknown asaas_payment_id", async () => {
+    const request = makeRequest(
+      { event: "PAYMENT_RECEIVED", payment: { id: "pay_unknown", value: 220 } },
+      "test-webhook-token",
+    )
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.error).toContain("No payment_request found")
+    expect(json.paymentId).toBe("pay_unknown")
+  })
+
+  it("returns 400 when payment.id is missing", async () => {
+    const request = makeRequest(
+      { event: "PAYMENT_RECEIVED", payment: {} },
+      "test-webhook-token",
+    )
+    const response = await action(actionArgs(request))
+    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.error).toContain("payment.id")
+  })
+
+  describe("PAYMENT_RECEIVED (PIX)", () => {
+    it("marks payment request as paid", async () => {
+      const row = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "awaiting_payment",
+        amount: 220,
+      }
+      mockSelectResult.value = row
+      mockUpdateResult.value = { ...row, status: "paid" }
+
+      const request = makeRequest(
+        { event: "PAYMENT_RECEIVED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      expect(response.status).toBe(200)
+      const json = await response.json()
+      expect(json.action).toBe("marked_paid")
+      expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+        expect.stringContaining("marked as paid"),
+        expect.objectContaining({ paymentRequestId: "pr-1" }),
+      )
+    })
+
+    it("skips paid update when row is no longer in pre-paid state (race)", async () => {
+      // SELECT sees awaiting_payment, but UPDATE with WHERE status IN
+      // (pending, awaiting_payment) matches 0 rows (another process changed
+      // it concurrently to a terminal state). Must NOT mark as paid.
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "awaiting_payment",
+        amount: 220,
+      }
+      mockUpdateResult.value = undefined
+
+      const request = makeRequest(
+        { event: "PAYMENT_RECEIVED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      expect(response.status).toBe(200)
+      const json = await response.json()
+      expect(json.skipped).toBe("already_terminal")
+    })
+  })
+
+  describe("PAYMENT_CONFIRMED (CC)", () => {
+    it("marks payment as paid (same as PAYMENT_RECEIVED)", async () => {
+      const row = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "awaiting_payment",
+        amount: 220,
+      }
+      mockSelectResult.value = row
+      mockUpdateResult.value = { ...row, status: "paid" }
+
+      const request = makeRequest(
+        { event: "PAYMENT_CONFIRMED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.action).toBe("marked_paid")
+    })
+
+    it("is idempotent — skips if already paid", async () => {
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "paid",
+        amount: 220,
+      }
+
+      const request = makeRequest(
+        { event: "PAYMENT_CONFIRMED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.skipped).toBe("already_paid")
+      expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+        expect.stringContaining("already paid"),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe("PAYMENT_OVERDUE", () => {
+    it("marks payment as expired", async () => {
+      const row = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "awaiting_payment",
+        amount: 220,
+      }
+      mockSelectResult.value = row
+      mockUpdateResult.value = { ...row, status: "expired" }
+
+      const request = makeRequest(
+        { event: "PAYMENT_OVERDUE", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.action).toBe("marked_expired")
+      expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+        expect.stringContaining("marked as expired"),
+        expect.anything(),
+      )
+    })
+
+    it("does NOT flip paid payment to expired (late/out-of-order webhook)", async () => {
+      // Critical guard: if Asaas sends PAYMENT_OVERDUE AFTER PAYMENT_CONFIRMED
+      // (retry, network reorder), we must NOT overwrite the paid status.
+      // SELECT sees paid; UPDATE with WHERE status IN (pending, awaiting)
+      // matches 0 rows → undefined → skip.
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "paid",
+        amount: 220,
+      }
+      mockUpdateResult.value = undefined
+
+      const request = makeRequest(
+        { event: "PAYMENT_OVERDUE", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      expect(response.status).toBe(200)
+      const json = await response.json()
+      expect(json.skipped).toBe("already_terminal")
+    })
+  })
+
+  describe("PAYMENT_REFUNDED", () => {
+    it("marks payment as refunded", async () => {
+      const row = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "paid",
+        amount: 220,
+      }
+      mockSelectResult.value = row
+      mockUpdateResult.value = { ...row, status: "refunded" }
+
+      const request = makeRequest(
+        { event: "PAYMENT_REFUNDED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(response.status).toBe(200)
+      expect(json.action).toBe("marked_refunded")
+    })
+
+    it("PAYMENT_REFUND_IN_PROGRESS is also handled", async () => {
+      const row = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "paid",
+        amount: 220,
+      }
+      mockSelectResult.value = row
+      mockUpdateResult.value = { ...row, status: "refunded" }
+
+      const request = makeRequest(
+        {
+          event: "PAYMENT_REFUND_IN_PROGRESS",
+          payment: { id: "pay_1", value: 220 },
+        },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.action).toBe("marked_refunded")
+    })
+
+    it("is idempotent — skips if already refunded", async () => {
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "refunded",
+        amount: 220,
+      }
+
+      const request = makeRequest(
+        { event: "PAYMENT_REFUNDED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.skipped).toBe("already_refunded")
+    })
+
+    it("skips if row is in a non-refundable state (e.g. pending)", async () => {
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "pending",
+        amount: 220,
+      }
+      mockUpdateResult.value = undefined
+
+      const request = makeRequest(
+        { event: "PAYMENT_REFUNDED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.skipped).toBe("already_terminal")
+    })
+
+    it("does NOT flip partially_refunded to fully refunded (would lose history)", async () => {
+      // Webhook handler must not overwrite refund_amount on a partial
+      // refund row — the actual refund value from the webhook payload
+      // is needed and we don't parse it yet.
+      mockSelectResult.value = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        status: "partially_refunded",
+        amount: 220,
+        refund_amount: 50,
+      }
+      mockUpdateResult.value = undefined
+
+      const request = makeRequest(
+        { event: "PAYMENT_REFUNDED", payment: { id: "pay_1", value: 220 } },
+        "test-webhook-token",
+      )
+      const response = await action(actionArgs(request))
+      const json = await response.json()
+      expect(json.skipped).toBe("already_terminal")
+    })
+  })
+})

--- a/app/routes/api.asaas-webhook.ts
+++ b/app/routes/api.asaas-webhook.ts
@@ -1,0 +1,327 @@
+import { timingSafeEqual } from "node:crypto"
+import type { ActionFunctionArgs } from "react-router"
+import { composable } from "composable-functions"
+import { env } from "~/env.server"
+import { kyselyDb } from "~/kysely-db"
+import { logger } from "~/lib/logger/logger.server"
+
+type WebhookAction =
+  | "marked_paid"
+  | "marked_expired"
+  | "marked_refunded"
+  | "unhandled_event"
+type WebhookSkipReason =
+  | "already_paid"
+  | "already_refunded"
+  | "already_terminal"
+
+export type AsaasWebhookSuccessResponse = {
+  received: true
+  action?: WebhookAction
+  skipped?: WebhookSkipReason
+  event?: string
+}
+
+export type AsaasWebhookErrorResponse = {
+  error: string
+  paymentId?: string
+  paymentRequestId?: string
+}
+
+export type AsaasWebhookResponse =
+  | AsaasWebhookSuccessResponse
+  | AsaasWebhookErrorResponse
+
+function ok(data: AsaasWebhookSuccessResponse) {
+  return Response.json(data satisfies AsaasWebhookResponse)
+}
+
+function fail(data: AsaasWebhookErrorResponse, status: number) {
+  return Response.json(data satisfies AsaasWebhookResponse, { status })
+}
+
+const PAYMENT_EVENTS = ["PAYMENT_RECEIVED", "PAYMENT_CONFIRMED"] as const
+const REFUND_EVENTS = ["PAYMENT_REFUNDED", "PAYMENT_REFUND_IN_PROGRESS"] as const
+
+let missingTokenWarned = false
+
+type TokenCheckResult =
+  | { ok: true }
+  | { ok: false; reason: "not_configured_in_production" | "invalid_token" }
+
+/**
+ * Constant-time compare. The length-mismatch branch deliberately performs a
+ * dummy compare against the SERVER-side token (`b`), not the attacker-controlled
+ * input (`a`). Comparing against the attacker buffer would make the dummy
+ * compare's runtime depend on the attacker's input length, leaking the
+ * server-side token length via observable timing differences.
+ *
+ * `timingSafeEqual` is implemented as a native binding so V8 cannot DCE the
+ * call; the discarded result is still observable side-effect-wise.
+ */
+function tokensEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a)
+  const bb = Buffer.from(b)
+  if (ba.length !== bb.length) {
+    // Dummy compare against the server token, NOT the attacker input.
+    timingSafeEqual(bb, bb)
+    return false
+  }
+  return timingSafeEqual(ba, bb)
+}
+
+function checkToken(request: Request): TokenCheckResult {
+  const { asaasWebhookToken, nodeEnv } = env()
+  if (!asaasWebhookToken) {
+    if (nodeEnv === "production") {
+      return { ok: false, reason: "not_configured_in_production" }
+    }
+    if (!missingTokenWarned) {
+      logger.warn(
+        "ASAAS_WEBHOOK_TOKEN not configured — webhook authentication disabled (dev/test only)",
+      )
+      missingTokenWarned = true
+    }
+    return { ok: true }
+  }
+  const header = request.headers.get("asaas-access-token")
+  if (!header || !tokensEqual(header, asaasWebhookToken)) {
+    return { ok: false, reason: "invalid_token" }
+  }
+  return { ok: true }
+}
+
+const findPaymentRequest = composable((asaasPaymentId: string) =>
+  kyselyDb
+    .selectFrom("payment_requests")
+    .selectAll()
+    .where("asaas_payment_id", "=", asaasPaymentId)
+    .executeTakeFirst(),
+)
+
+// Only flip to paid if still in a non-terminal pre-paid state. Guards
+// against out-of-order webhooks (e.g. a stale PAYMENT_RECEIVED arriving
+// after a refund).
+const markAsPaid = composable(async (paymentRequestId: string) => {
+  const now = new Date().toISOString()
+  return kyselyDb
+    .updateTable("payment_requests")
+    .set({ status: "paid" as const, paid_at: now, updated_at: now })
+    .where("id", "=", paymentRequestId)
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst()
+})
+
+// Only expire a row that hasn't already reached a terminal state. Without
+// this guard, a late PAYMENT_OVERDUE can silently flip a paid row back
+// to expired.
+const markAsExpired = composable((paymentRequestId: string) =>
+  kyselyDb
+    .updateTable("payment_requests")
+    .set({ status: "expired" as const, updated_at: new Date().toISOString() })
+    .where("id", "=", paymentRequestId)
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst(),
+)
+
+// Mark refunded based on external Asaas webhook. Only flips rows that are
+// currently `paid`. Rows already in `partially_refunded` are intentionally
+// excluded — overwriting `refund_amount` with the full amount would mask
+// existing partial refund history, and we'd need the actual refund value
+// from the webhook payload to handle partials correctly. We don't yet
+// support partial refunds in the app, so this guard keeps us safe.
+//
+// Note: when partial refunds are added in the future, parse the actual refund
+// value from `body.payment.value` (or whichever field Asaas exposes) and
+// update `refund_amount` additively rather than overwriting.
+const markAsRefunded = composable((paymentRequestId: string, amount: number) =>
+  kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      status: "refunded" as const,
+      refund_amount: amount,
+      refunded_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", paymentRequestId)
+    .where("status", "=", "paid")
+    .returningAll()
+    .executeTakeFirst(),
+)
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (!env().paymentSystemOnline) {
+    return fail({ error: "Payment system offline" }, 404)
+  }
+
+  const tokenCheck = checkToken(request)
+  if (!tokenCheck.ok) {
+    if (tokenCheck.reason === "not_configured_in_production") {
+      logger.error(
+        "ASAAS_WEBHOOK_TOKEN not configured in production — rejecting webhook",
+      )
+      return fail({ error: "Webhook token not configured" }, 503)
+    }
+    logger.warn("Asaas webhook received with invalid token")
+    return fail({ error: "Invalid webhook token" }, 401)
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body) {
+    logger.warn("Asaas webhook received with empty or unparseable body")
+    return fail({ error: "Missing or invalid JSON body" }, 400)
+  }
+
+  const event = body.event as string
+  const paymentId = body.payment?.id as string | undefined
+
+  if (!paymentId) {
+    logger.warn("Asaas webhook missing payment id", { event })
+    return fail({ error: "Missing payment.id in webhook body" }, 400)
+  }
+
+  logger.info("Asaas webhook received", {
+    event,
+    paymentId,
+    value: body.payment?.value,
+  })
+
+  const findResult = await findPaymentRequest(paymentId)
+  if (!findResult.success) {
+    logger.error("Failed to query payment_requests table", {
+      paymentId,
+      errors: findResult.errors,
+    })
+    return fail(
+      { error: "Database error looking up payment request", paymentId },
+      500,
+    )
+  }
+
+  const paymentRequest = findResult.data
+  if (!paymentRequest) {
+    logger.warn("Payment request not found for asaas_payment_id", { paymentId })
+    return fail({ error: "No payment_request found", paymentId }, 200)
+  }
+
+  if (PAYMENT_EVENTS.includes(event as (typeof PAYMENT_EVENTS)[number])) {
+    if (paymentRequest.status === "paid") {
+      logger.info("Payment already paid, skipping", {
+        paymentRequestId: paymentRequest.id,
+      })
+      return ok({ received: true, skipped: "already_paid" })
+    }
+
+    const paidResult = await markAsPaid(paymentRequest.id)
+    if (!paidResult.success) {
+      logger.error("Failed to mark payment as paid", {
+        paymentRequestId: paymentRequest.id,
+        errors: paidResult.errors,
+      })
+      return fail(
+        {
+          error: "Database error updating payment to paid",
+          paymentRequestId: paymentRequest.id,
+        },
+        500,
+      )
+    }
+
+    if (!paidResult.data) {
+      logger.info(
+        "Skipped mark-as-paid: row is no longer in a pre-paid state",
+        {
+          paymentRequestId: paymentRequest.id,
+          currentStatus: paymentRequest.status,
+        },
+      )
+      return ok({ received: true, skipped: "already_terminal" })
+    }
+
+    logger.info("Payment marked as paid", {
+      paymentRequestId: paymentRequest.id,
+      eventParticipantId: paymentRequest.event_participant_id,
+    })
+    return ok({ received: true, action: "marked_paid" })
+  }
+
+  if (event === "PAYMENT_OVERDUE") {
+    const expiredResult = await markAsExpired(paymentRequest.id)
+    if (!expiredResult.success) {
+      logger.error("Failed to mark payment as expired", {
+        paymentRequestId: paymentRequest.id,
+        errors: expiredResult.errors,
+      })
+      return fail(
+        {
+          error: "Database error updating payment to expired",
+          paymentRequestId: paymentRequest.id,
+        },
+        500,
+      )
+    }
+
+    if (!expiredResult.data) {
+      logger.info(
+        "Skipped mark-as-expired: row is no longer in a non-terminal state",
+        {
+          paymentRequestId: paymentRequest.id,
+          currentStatus: paymentRequest.status,
+        },
+      )
+      return ok({ received: true, skipped: "already_terminal" })
+    }
+
+    logger.info("Payment marked as expired", {
+      paymentRequestId: paymentRequest.id,
+    })
+    return ok({ received: true, action: "marked_expired" })
+  }
+
+  if (REFUND_EVENTS.includes(event as (typeof REFUND_EVENTS)[number])) {
+    if (paymentRequest.status === "refunded") {
+      logger.info("Payment already refunded, skipping", {
+        paymentRequestId: paymentRequest.id,
+      })
+      return ok({ received: true, skipped: "already_refunded" })
+    }
+
+    const amount = Number(paymentRequest.amount)
+    const refundedResult = await markAsRefunded(paymentRequest.id, amount)
+    if (!refundedResult.success) {
+      logger.error("Failed to mark payment as refunded", {
+        paymentRequestId: paymentRequest.id,
+        errors: refundedResult.errors,
+      })
+      return fail(
+        {
+          error: "Database error updating payment to refunded",
+          paymentRequestId: paymentRequest.id,
+        },
+        500,
+      )
+    }
+
+    if (!refundedResult.data) {
+      logger.warn(
+        "Skipped mark-as-refunded: row is not in a refundable state",
+        {
+          paymentRequestId: paymentRequest.id,
+          currentStatus: paymentRequest.status,
+        },
+      )
+      return ok({ received: true, skipped: "already_terminal" })
+    }
+
+    logger.info("Payment marked as refunded", {
+      paymentRequestId: paymentRequest.id,
+      event,
+    })
+    return ok({ received: true, action: "marked_refunded" })
+  }
+
+  logger.info("Unhandled Asaas webhook event", { event, paymentId })
+  return ok({ received: true, action: "unhandled_event", event })
+}

--- a/app/routes/api.asaas-webhook.ts
+++ b/app/routes/api.asaas-webhook.ts
@@ -136,20 +136,21 @@ const markAsExpired = composable((paymentRequestId: string) =>
 // Note: when partial refunds are added in the future, parse the actual refund
 // value from `body.payment.value` (or whichever field Asaas exposes) and
 // update `refund_amount` additively rather than overwriting.
-const markAsRefunded = composable((paymentRequestId: string, amount: number) =>
-  kyselyDb
+const markAsRefunded = composable((paymentRequestId: string, amount: number) => {
+  const now = new Date().toISOString()
+  return kyselyDb
     .updateTable("payment_requests")
     .set({
       status: "refunded" as const,
       refund_amount: amount,
-      refunded_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
+      refunded_at: now,
+      updated_at: now,
     })
     .where("id", "=", paymentRequestId)
     .where("status", "=", "paid")
     .returningAll()
-    .executeTakeFirst(),
-)
+    .executeTakeFirst()
+})
 
 export async function action({ request }: ActionFunctionArgs) {
   if (!env().paymentSystemOnline) {


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 4 — webhook endpoint, part of the payment system rebuild)

## Summary

Fourth atomic slice of the Sistema de Pagamentos rebuild. Adds the Asaas webhook handler that processes payment lifecycle events and updates `payment_requests` status.

### Webhook handler (POST `/api/asaas-webhook`)

- **Timing-safe token comparison** (§3.4): dummy compare against server token on length mismatch, not attacker input — prevents token-length leakage via timing side-channel
- **Production rejects with 503** if `ASAAS_WEBHOOK_TOKEN` missing (§3.5) — dev/test logs one-time warning and allows unauthenticated
- **Status-guarded transitions** (§3.1, §3.6):
  - `markAsPaid`: `WHERE status IN ('pending', 'awaiting_payment')` + `returningAll()`
  - `markAsExpired`: same guard — late `PAYMENT_OVERDUE` after paid is a no-op
  - `markAsRefunded`: `WHERE status = 'paid'` — excludes `partially_refunded` to preserve partial refund audit trail
- **Handled events**: `PAYMENT_RECEIVED` (PIX), `PAYMENT_CONFIRMED` (CC), `PAYMENT_OVERDUE`, `PAYMENT_REFUNDED`, `PAYMENT_REFUND_IN_PROGRESS`
- **Idempotent**: already-paid / already-refunded skip gracefully with `skipped` field in response
- Always returns 200 for valid handled events (prevents Asaas delivery retries)
- Uses `composable-functions` pattern for DB operations

### Cherry-pick sources

- `a7787647` — initial webhook scaffold
- `4704569c` — token validation + payment reconciliation
- `83c19e46` — refactor to single source of truth (no dual-write to event_participants)
- Webhook parts of `4da13d5c` (MEGA BLASTER) — timing-safe token, status guards on all handlers, REFUNDED handler, AbortController timeout
- Webhook parts of `969f8ef7` (MEGA round 2) — fix timing-safe dummy compare direction, exclude `partially_refunded` from refund guard

## How to test manually

1. `pnpm lint` — green
2. `pnpm test` — 173 files, 1651 tests pass (18 new webhook tests)
3. In dev: `curl -X POST http://localhost:5173/api/asaas-webhook` returns 404 (payment system offline by default)

## Implementation Notes

### ⚠️ 715 lines (327 impl + 388 tests)

Above the ~500 line cap, but splitting the webhook handler would create artificial seams — the token check, event dispatch, and status guards are tightly coupled. The 388-line test file is comprehensive coverage, not bloat.

### ⚠️ No integration tests in this PR

Unit tests use a Kysely proxy mock (§5.7 caveat). The race-condition guards (`WHERE status IN (...)` + `returningAll()`) are verified via the mock's `mockSelectResult`/`mockUpdateResult` split, which simulates the SELECT-sees-one-thing / UPDATE-matches-zero-rows race pattern. Real-DB integration tests for these races arrive in PR #7 (business logic) per the original plan.

### ⚠️ `composable-functions` dependency

Already installed (`^5.0.0` in `package.json`). Used for DB operation wrappers that return `{ success, data, errors }` — consistent with existing codebase patterns.

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 173 files, 1651 tests pass
- `pnpm test:integration` ✅ — 28 files, 270 tests pass

## Breaking Changes

None. New route only. No existing behavior modified.

## Invariants touched

Per [§3 Critical Invariants](docs/payment-system-architecture.md#3-critical-invariants-do-not-break):

- §3.1 — Atomic status transitions with `returningAll().executeTakeFirst()` ✅
- §3.4 — Timing-safe webhook token comparison ✅
- §3.5 — Missing token in production rejects with 503 ✅
- §3.6 — Status guards on all webhook handlers ✅

## Rollback

`git revert` the commit. The webhook route has no consumers yet (Asaas webhook URL is configured per-environment, not in code). No migration involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)