### PR TITLE
[POS-464] Pricing engine + payment options builder

### DIFF
--- a/app/business/email/format-payment-link-mail.test.ts
+++ b/app/business/email/format-payment-link-mail.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { formatPaymentLinkMail } from "./format-payment-link-mail"
-import type { PaymentOption } from "~/business/email/payment-email.types"
+import type { PaymentOption } from "~/business/payment/payment-pricing.server"
 
 const testPaymentOptions: PaymentOption[] = [
   { value: "PIX", billingType: "PIX", installments: 1, totalReais: 220, perInstallmentReais: 220 },

--- a/app/business/email/format-payment-link-mail.ts
+++ b/app/business/email/format-payment-link-mail.ts
@@ -1,5 +1,5 @@
 import { htmlToText } from "html-to-text"
-import type { PaymentOption } from "~/business/email/payment-email.types"
+import type { PaymentOption } from "~/business/payment/payment-pricing.server"
 import { paymentLinkMailTemplate } from "./templates/payment-link-mail.template"
 
 type FormatPaymentLinkMailParams = {

--- a/app/business/email/payment-email.types.ts
+++ b/app/business/email/payment-email.types.ts
@@ -1,7 +1,0 @@
-export type PaymentOption = {
-  value: string
-  billingType: "PIX" | "CREDIT_CARD"
-  installments: number
-  totalReais: number
-  perInstallmentReais: number
-}

--- a/app/business/email/templates/payment-link-mail.template.test.ts
+++ b/app/business/email/templates/payment-link-mail.template.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { paymentLinkMailTemplate } from "./payment-link-mail.template"
-import type { PaymentOption } from "~/business/email/payment-email.types"
+import type { PaymentOption } from "~/business/payment/payment-pricing.server"
 
 const testPaymentOptions: PaymentOption[] = [
   { value: "PIX", billingType: "PIX", installments: 1, totalReais: 220, perInstallmentReais: 220 },

--- a/app/business/email/templates/payment-link-mail.template.ts
+++ b/app/business/email/templates/payment-link-mail.template.ts
@@ -1,7 +1,7 @@
 import { POSITIV_URL } from "~/lib/constants/constants"
 import { formatCurrency } from "~/lib/helpers/chart-utils"
 import { sanitizeHtml } from "~/lib/email/sanitize-html"
-import type { PaymentOption } from "~/business/email/payment-email.types"
+import type { PaymentOption } from "~/business/payment/payment-pricing.server"
 
 type PaymentLinkMailParams = {
   participantName: string

--- a/app/business/payment/payment-form-schema.test.ts
+++ b/app/business/payment/payment-form-schema.test.ts
@@ -1,100 +1,48 @@
 import { describe, it, expect } from "vitest"
-import { paymentFormSchema } from "./payment-form-schema"
+import { paymentFormSchema, VALID_PAYMENT_OPTIONS } from "./payment-form-schema"
+import { MAX_INSTALLMENTS } from "./payment-pricing.server"
 
 describe("paymentFormSchema", () => {
-  it("accepts PIX with default installmentCount", () => {
-    const result = paymentFormSchema.safeParse({ billingType: "PIX" })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.installmentCount).toBe(1)
+  it("VALID_PAYMENT_OPTIONS matches MAX_INSTALLMENTS", () => {
+    // This test guards against drift between the shared client/server
+    // enum and the server-only MAX_INSTALLMENTS constant.
+    const expected = [
+      "PIX",
+      ...Array.from({ length: MAX_INSTALLMENTS }, (_, i) => `CC_${i + 1}`),
+    ]
+    expect([...VALID_PAYMENT_OPTIONS]).toEqual(expected)
+  })
+
+  it("accepts PIX", () => {
+    expect(
+      paymentFormSchema.safeParse({ paymentOption: "PIX" }).success,
+    ).toBe(true)
+  })
+
+  it("accepts CC_1 through CC_4", () => {
+    for (const value of ["CC_1", "CC_2", "CC_3", "CC_4"]) {
+      expect(
+        paymentFormSchema.safeParse({ paymentOption: value }).success,
+        `${value} should be valid`,
+      ).toBe(true)
     }
   })
 
-  it("accepts CREDIT_CARD with explicit installmentCount", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "CREDIT_CARD",
-      installmentCount: 3,
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.installmentCount).toBe(3)
-    }
+  it("rejects CC_5 and higher", () => {
+    expect(
+      paymentFormSchema.safeParse({ paymentOption: "CC_5" }).success,
+    ).toBe(false)
+    expect(
+      paymentFormSchema.safeParse({ paymentOption: "CC_999" }).success,
+    ).toBe(false)
   })
 
-  it("coerces empty string installmentCount to 1", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "PIX",
-      installmentCount: "",
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.installmentCount).toBe(1)
-    }
-  })
-
-  it("coerces null installmentCount to 1", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "PIX",
-      installmentCount: null,
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.installmentCount).toBe(1)
-    }
-  })
-
-  it("rejects unknown billingType", () => {
-    const result = paymentFormSchema.safeParse({ billingType: "BOLETO" })
-    expect(result.success).toBe(false)
-  })
-
-  it("rejects missing billingType", () => {
-    const result = paymentFormSchema.safeParse({})
-    expect(result.success).toBe(false)
-  })
-
-  it("rejects installmentCount below 1", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "CREDIT_CARD",
-      installmentCount: 0,
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it("rejects installmentCount above 3", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "CREDIT_CARD",
-      installmentCount: 4,
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it("rejects non-integer installmentCount", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "CREDIT_CARD",
-      installmentCount: 2.5,
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it("rejects PIX with installmentCount > 1 (PIX doesn't support installments)", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "PIX",
-      installmentCount: 3,
-    })
-    expect(result.success).toBe(false)
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "installmentCount")).toBe(
-        true,
-      )
-    }
-  })
-
-  it("accepts PIX with installmentCount = 1 explicitly", () => {
-    const result = paymentFormSchema.safeParse({
-      billingType: "PIX",
-      installmentCount: 1,
-    })
-    expect(result.success).toBe(true)
+  it("rejects empty and invalid strings", () => {
+    expect(paymentFormSchema.safeParse({ paymentOption: "" }).success).toBe(
+      false,
+    )
+    expect(
+      paymentFormSchema.safeParse({ paymentOption: "invalid" }).success,
+    ).toBe(false)
   })
 })

--- a/app/business/payment/payment-form-schema.ts
+++ b/app/business/payment/payment-form-schema.ts
@@ -1,29 +1,15 @@
 import { type z } from "zod"
 import { zod } from "~/lib/helpers/zod"
 
-// Transitional: a later PR replaces `billingType` + `installmentCount` with
-// a single `paymentOption` enum (`["PIX", "CC_1", ..., "CC_<MAX_INSTALLMENTS>"]`)
-// — see `docs/payment-system-architecture.md` §3.9.
-export const paymentFormSchema = zod
-  .object({
-    billingType: zod.enum(["PIX", "CREDIT_CARD"], {
-      message: "Selecione uma forma de pagamento",
-    }),
-    installmentCount: zod.preprocess(
-      (val) => (val === null || val === undefined || val === "" ? 1 : val),
-      zod.coerce.number().int().min(1).max(3),
-    ),
-  })
-  // PIX never supports installments — catching this at the schema
-  // boundary is defense-in-depth against the runtime throw in
-  // `createAsaasPayment`. Will be superseded by the unified paymentOption
-  // enum in a later PR.
-  .refine(
-    (data) => data.billingType !== "PIX" || data.installmentCount === 1,
-    {
-      message: "Pix não aceita parcelamento",
-      path: ["installmentCount"],
-    },
-  )
+// Must mirror MAX_INSTALLMENTS in payment-pricing.server.ts.
+// Inlined because this schema is shared with the client and cannot
+// import from .server modules.
+export const VALID_PAYMENT_OPTIONS = ["PIX", "CC_1", "CC_2", "CC_3", "CC_4"] as const
+
+export const paymentFormSchema = zod.object({
+  paymentOption: zod.enum(VALID_PAYMENT_OPTIONS, {
+    message: "Selecione uma forma de pagamento válida",
+  }),
+})
 
 export type PaymentFormData = z.infer<typeof paymentFormSchema>

--- a/app/business/payment/payment-pricing.server.test.ts
+++ b/app/business/payment/payment-pricing.server.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest"
+import {
+  buildPaymentOptions,
+  calculateChargeAmount,
+  calculateInstallmentValue,
+  MAX_INSTALLMENTS,
+} from "./payment-pricing.server"
+
+describe("calculateChargeAmount", () => {
+  it("single installment (PIX/CC 1x) — Asaas 1x fee: 2.99% + R$0.49", () => {
+    // Formula: (price_cents / anticipationFactor + fixed_fee) / (1 - percent_fee)
+    // For 1x: anticipationFactor = 1 - 0.0115 * 1 = 0.9885 ≈ 1 (but code uses it)
+    // price=100 => ceil((10000/0.9885 + 49) / (1 - 0.0299)) / 100 = ceil((10116.34 + 49) / 0.9701) / 100
+    //           = ceil(10478.84) / 100 = 104.79
+    const result = calculateChargeAmount(100, 1)
+    expect(result).toBe(104.79)
+  })
+
+  it("2x installment uses 3.49% + R$0.49 config", () => {
+    // anticipationFactor = 1 - 0.016 * 2 = 0.968
+    const result = calculateChargeAmount(100, 2)
+    // Verify it's more than 1x since fees are higher + anticipation
+    expect(result).toBeGreaterThan(calculateChargeAmount(100, 1))
+  })
+
+  it("4x installment charges more than 2x (more anticipation)", () => {
+    expect(calculateChargeAmount(100, 4)).toBeGreaterThan(
+      calculateChargeAmount(100, 2),
+    )
+  })
+
+  it("throws for installments > 6 (Asaas unsupported)", () => {
+    expect(() => calculateChargeAmount(100, 7)).toThrow(
+      "Unsupported installment count",
+    )
+  })
+
+  it("rounds UP to nearest cent (gateway fee safety)", () => {
+    // Any fractional cent must round up so Asaas fees never push us below
+    // the ticket price
+    const result = calculateChargeAmount(100, 1)
+    const cents = Math.round(result * 100)
+    expect(cents).toBe(10479) // exact cents, no fractions
+  })
+})
+
+describe("calculateInstallmentValue", () => {
+  it("1x installment equals charge amount", () => {
+    const total = calculateChargeAmount(100, 1)
+    const perInstallment = calculateInstallmentValue(100, 1)
+    expect(perInstallment).toBe(total)
+  })
+
+  it("2x installment value × 2 is close to (not less than) charge amount", () => {
+    const perInstallment = calculateInstallmentValue(100, 2)
+    const total = calculateChargeAmount(100, 2)
+    // Each installment rounds up independently, so total may be a cent
+    // higher than the computed charge amount.
+    expect(perInstallment * 2).toBeGreaterThanOrEqual(total)
+    expect(perInstallment * 2 - total).toBeLessThan(0.1)
+  })
+})
+
+describe("buildPaymentOptions", () => {
+  it("returns PIX + CC 1 through MAX_INSTALLMENTS", () => {
+    const options = buildPaymentOptions(100)
+    expect(options).toHaveLength(1 + MAX_INSTALLMENTS)
+    expect(options[0].value).toBe("PIX")
+    expect(options[0].billingType).toBe("PIX")
+    for (let i = 1; i <= MAX_INSTALLMENTS; i++) {
+      const opt = options[i]
+      expect(opt.value).toBe(`CC_${i}`)
+      expect(opt.billingType).toBe("CREDIT_CARD")
+      expect(opt.installments).toBe(i)
+    }
+  })
+
+  it("PIX totalReais equals ticket price (no fees passed to user)", () => {
+    const [pix] = buildPaymentOptions(220)
+    expect(pix.totalReais).toBe(220)
+    expect(pix.perInstallmentReais).toBe(220)
+  })
+
+  it("CC options charge more than PIX (fees)", () => {
+    const [pix, cc1] = buildPaymentOptions(220)
+    expect(cc1.totalReais).toBeGreaterThan(pix.totalReais)
+  })
+
+  it("Higher installments always cost more total", () => {
+    const options = buildPaymentOptions(220)
+    const ccOnly = options.filter((o) => o.billingType === "CREDIT_CARD")
+    for (let i = 1; i < ccOnly.length; i++) {
+      expect(ccOnly[i].totalReais).toBeGreaterThan(ccOnly[i - 1].totalReais)
+    }
+  })
+
+  it("perInstallmentReais × installments is close to (>=) totalReais", () => {
+    const options = buildPaymentOptions(220)
+    for (const opt of options) {
+      const product = Math.round(opt.perInstallmentReais * opt.installments * 100) / 100
+      expect(product).toBeGreaterThanOrEqual(opt.totalReais - 0.01)
+    }
+  })
+
+  it("MAX_INSTALLMENTS is within Asaas's supported range (1-6)", () => {
+    // Guard: payment-pricing only configures fees for 1 and 2-6 tiers.
+    // If MAX_INSTALLMENTS ever exceeds 6, calculateChargeAmount throws.
+    expect(MAX_INSTALLMENTS).toBeLessThanOrEqual(6)
+    expect(MAX_INSTALLMENTS).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/app/business/payment/payment-pricing.server.ts
+++ b/app/business/payment/payment-pricing.server.ts
@@ -19,7 +19,7 @@ const ASAAS_FEE_CONFIG: Record<string, InstallmentFeeConfig> = {
 
 function getFeeConfig(installments: number): InstallmentFeeConfig {
   if (installments === 1) return ASAAS_FEE_CONFIG["1"]
-  if (installments <= 6) return ASAAS_FEE_CONFIG["2-6"]
+  if (installments >= 2 && installments <= 6) return ASAAS_FEE_CONFIG["2-6"]
   throw new Error(`Unsupported installment count: ${installments}`)
 }
 
@@ -68,6 +68,10 @@ export function buildPaymentOptions(ticketPrice: number): PaymentOption[] {
 
   for (let i = 1; i <= MAX_INSTALLMENTS; i++) {
     const perInstallmentReais = calculateInstallmentValue(ticketPrice, i)
+    // totalReais is derived from the rounded-up per-installment value × count,
+    // NOT directly from calculateChargeAmount. This can be 1-2 centavos higher
+    // than the Asaas charge — intentional, so the displayed total matches
+    // what the participant actually pays across installments.
     const totalReais =
       Math.round(perInstallmentReais * i * 100) / 100
 

--- a/app/business/payment/payment-pricing.server.ts
+++ b/app/business/payment/payment-pricing.server.ts
@@ -1,0 +1,84 @@
+interface InstallmentFeeConfig {
+  percentFee: number
+  fixedFeeCents: number
+  monthlyAnticipationRate: number
+}
+
+const ASAAS_FEE_CONFIG: Record<string, InstallmentFeeConfig> = {
+  "1": {
+    percentFee: 0.0299,
+    fixedFeeCents: 49,
+    monthlyAnticipationRate: 0.0115,
+  },
+  "2-6": {
+    percentFee: 0.0349,
+    fixedFeeCents: 49,
+    monthlyAnticipationRate: 0.016,
+  },
+}
+
+function getFeeConfig(installments: number): InstallmentFeeConfig {
+  if (installments === 1) return ASAAS_FEE_CONFIG["1"]
+  if (installments <= 6) return ASAAS_FEE_CONFIG["2-6"]
+  throw new Error(`Unsupported installment count: ${installments}`)
+}
+
+export function calculateChargeAmount(
+  ticketPrice: number,
+  installments: number,
+): number {
+  const ticketPriceCents = Math.round(ticketPrice * 100)
+  const { percentFee, fixedFeeCents, monthlyAnticipationRate } =
+    getFeeConfig(installments)
+  const anticipationFactor = 1 - monthlyAnticipationRate * installments
+  const grossCents =
+    (ticketPriceCents / anticipationFactor + fixedFeeCents) / (1 - percentFee)
+  return Math.ceil(grossCents) / 100
+}
+
+export function calculateInstallmentValue(
+  ticketPrice: number,
+  installments: number,
+): number {
+  const totalReais = calculateChargeAmount(ticketPrice, installments)
+  const totalCents = Math.round(totalReais * 100)
+  return Math.ceil(totalCents / installments) / 100
+}
+
+export type PaymentOption = {
+  value: string
+  billingType: "PIX" | "CREDIT_CARD"
+  installments: number
+  totalReais: number
+  perInstallmentReais: number
+}
+
+export const MAX_INSTALLMENTS = 4
+
+export function buildPaymentOptions(ticketPrice: number): PaymentOption[] {
+  const options: PaymentOption[] = [
+    {
+      value: "PIX",
+      billingType: "PIX",
+      installments: 1,
+      totalReais: ticketPrice,
+      perInstallmentReais: ticketPrice,
+    },
+  ]
+
+  for (let i = 1; i <= MAX_INSTALLMENTS; i++) {
+    const perInstallmentReais = calculateInstallmentValue(ticketPrice, i)
+    const totalReais =
+      Math.round(perInstallmentReais * i * 100) / 100
+
+    options.push({
+      value: `CC_${i}`,
+      billingType: "CREDIT_CARD",
+      installments: i,
+      totalReais,
+      perInstallmentReais,
+    })
+  }
+
+  return options
+}


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 6 — pricing engine, part of the payment system rebuild)

## Summary

Sixth atomic slice of the Sistema de Pagamentos rebuild. Adds the pricing computation layer that the rest of the system references for payment amounts.

### Pricing engine (`payment-pricing.server.ts`)
- `calculateChargeAmount(ticketPrice, installments)`: total charge = ticket price + Asaas processing fees + antecipação automática rates. Internal math in cents for precision, output in reais.
- `calculateInstallmentValue(ticketPrice, installments)`: per-installment value, rounded up to the nearest centavo.
- `buildPaymentOptions(ticketPrice)`: generates PIX + CC 1-4x options with computed prices.
- `MAX_INSTALLMENTS = 4`
- `PaymentOption` type (canonical source — replaces the stopgap `payment-email.types.ts` from PR #5)

### Form schema update (`payment-form-schema.ts`)
- Simplified from `billingType` + `installmentCount` to a single `paymentOption` enum: `PIX`, `CC_1`..`CC_4`
- `VALID_PAYMENT_OPTIONS` inlined (can't import `.server` modules in shared client/server schema)
- Drift guard test: `VALID_PAYMENT_OPTIONS` must match `MAX_INSTALLMENTS` — fails if either changes without the other

### Email import consolidation
- Removed `payment-email.types.ts` (stopgap from PR #5)
- Email templates + formatters now import `PaymentOption` from `payment-pricing.server.ts`

### Cherry-pick sources
- `51e9db16` — dynamic pricing with Asaas fee calculation
- `52e66006` — reais at boundaries, cents only for internal math
- Pricing tests from `4da13d5c` (MEGA BLASTER)

## How to test manually

1. `pnpm lint` — green
2. `pnpm test` — 179 files, 1678 tests pass (18 new)

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 179 files, 1678 tests pass
- `pnpm test:integration` ✅ — 28 files, 270 tests pass

## Breaking Changes

None. `payment-form-schema.ts` API changed (single `paymentOption` field replaces `billingType` + `installmentCount`), but the old form schema had no consumers on the `payment` branch — only the scaffold tests from PR #1, which are updated here.

## Rollback

`git revert` the commit. No route or DB consumer yet — pricing is called by the payment page (PR #9) and the payment-link email sender (PR #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)