### PR TITLE
[POS-464] Payment-request business logic: CRUD + race-safe atomic transitions

### DIFF
--- a/app/business/payment/cancelActivePaymentRequest-race.integration.test.ts
+++ b/app/business/payment/cancelActivePaymentRequest-race.integration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+import { setupIntegrationTest, cleanupAfterTest } from "~/test/integration-setup"
+import {
+  createTestProfile,
+  createTestEvent,
+  createTestEventParticipant,
+} from "~/test/db-test-utils"
+import { cancelActivePaymentRequest } from "./payment-request.server"
+import * as asaasClient from "./asaas-client.server"
+import { kyselyDb } from "~/kysely-db"
+
+describe("cancelActivePaymentRequest — race condition (integration)", () => {
+  const { tracker, kysely } = setupIntegrationTest()
+
+  beforeEach(() => {
+    tracker.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(async () => {
+    await cleanupAfterTest(tracker, kysely)
+  })
+
+  it("must NOT clobber a concurrently-updated row (e.g. paid via webhook)", async () => {
+    const profile = await createTestProfile(tracker, kysely, {
+      user_id: null,
+      email: `cancel-race-${Date.now()}@test.example`,
+      full_name: "Cancel Race",
+      cpf: "12345678900",
+    })
+    const event = await createTestEvent(tracker, kysely, {
+      title: "Cancel Race Event",
+      ticket_price: 100,
+    })
+    const ep = await createTestEventParticipant(tracker, kysely, {
+      profile_id: profile.id,
+      event_id: event.id,
+      application_status: "sent_payment_data",
+    })
+
+    const pr = await kysely
+      .insertInto("payment_requests")
+      .values({
+        event_participant_id: ep.id,
+        amount: 100,
+        status: "pending",
+        payment_mode: "automatic",
+        asaas_payment_id: "pay_cancel_race_test",
+        expires_at: new Date(Date.now() + 60000).toISOString(),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    tracker.track("payment_requests", pr.id)
+
+    const cancelSpy = vi
+      .spyOn(asaasClient, "cancelAsaasPayment")
+      .mockResolvedValue(undefined)
+
+    // Scenario: row gets paid (e.g. via webhook) BEFORE admin clicks cancel.
+    // getActivePaymentRequest returns non-cancelled non-expired rows, so a
+    // "paid" row still passes that filter. The fixed code's UPDATE has
+    // WHERE status IN (pending, awaiting_payment) — so against a paid row
+    // the UPDATE must NOT succeed, and Asaas cancel must NOT be called.
+    //
+    // Without the guard (the bug), cancel would:
+    //   - call Asaas cancel on a paid charge (reversing a legit payment!)
+    //   - flip DB status from paid → cancelled (wipes paid_at)
+    await kyselyDb
+      .updateTable("payment_requests")
+      .set({ status: "paid", paid_at: new Date().toISOString() })
+      .where("id", "=", pr.id)
+      .execute()
+
+    await cancelActivePaymentRequest(ep.id)
+
+    const finalPr = await kyselyDb
+      .selectFrom("payment_requests")
+      .selectAll()
+      .where("id", "=", pr.id)
+      .executeTakeFirstOrThrow()
+
+    expect(
+      finalPr.status,
+      "paid status MUST NOT be clobbered by cancel",
+    ).toBe("paid")
+    expect(
+      cancelSpy,
+      "Asaas cancel MUST NOT be called against a paid charge",
+    ).not.toHaveBeenCalled()
+  })
+})

--- a/app/business/payment/payment-request.integration.test.ts
+++ b/app/business/payment/payment-request.integration.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest"
+import { setupIntegrationTest, cleanupAfterTest } from "~/test/integration-setup"
+import {
+  createTestProfile,
+  createTestEvent,
+  createTestEventParticipant,
+  createTestPaymentRequest,
+} from "~/test/db-test-utils"
+import {
+  getActivePaymentRequest,
+  markPaymentAsExpired,
+} from "./payment-request.server"
+
+describe("payment-request - Integration Tests", () => {
+  const { tracker, kysely } = setupIntegrationTest()
+
+  beforeEach(async () => {
+    tracker.clear()
+  })
+
+  afterEach(async () => {
+    await cleanupAfterTest(tracker, kysely)
+  })
+
+  async function setupParticipant(overrides?: { ticketPrice?: number }) {
+    const profile = await createTestProfile(tracker, kysely, {
+      user_id: null,
+      email: `payment-test-${Date.now()}@test.com`,
+      full_name: "Test Participant",
+      cpf: "12345678900",
+    })
+
+    const event = await createTestEvent(tracker, kysely, {
+      title: "Test Payment Event",
+      ticket_price: overrides?.ticketPrice ?? 220,
+    })
+
+    const participant = await createTestEventParticipant(tracker, kysely, {
+      profile_id: profile.id,
+      event_id: event.id,
+    })
+
+    return { profile, event, participant }
+  }
+
+  describe("createPaymentRequest", () => {
+    it("creates a payment request row with correct fields", async () => {
+      const { participant } = await setupParticipant()
+
+      const request = await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+
+      expect(request.id).toBeDefined()
+      expect(request.event_participant_id).toBe(participant.id)
+      expect(Number(request.amount)).toBe(220)
+      expect(request.status).toBe("pending")
+      expect(request.asaas_payment_id).toBeNull()
+      expect(request.asaas_customer_id).toBeNull()
+    })
+  })
+
+  describe("getActivePaymentRequest", () => {
+    it("returns active (non-expired, non-cancelled) request", async () => {
+      const { participant } = await setupParticipant()
+
+      const request = await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        status: "pending",
+      })
+
+      const active = await getActivePaymentRequest(participant.id)
+
+      expect(active).not.toBeNull()
+      expect(active?.id).toBe(request.id)
+    })
+
+    it("returns null for requests whose expires_at is in the past", async () => {
+      const { participant } = await setupParticipant()
+
+      // The CHECK constraint requires expires_at > created_at, so to
+      // simulate an expired row we push created_at far into the past and
+      // set expires_at to just before now.
+      const pastCreated = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+      const pastExpiry = new Date(Date.now() - 1000).toISOString()
+      await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        status: "pending",
+        created_at: pastCreated,
+        expires_at: pastExpiry,
+      })
+
+      const active = await getActivePaymentRequest(participant.id)
+
+      expect(active).toBeNull()
+    })
+
+    it("returns null for cancelled requests", async () => {
+      const { participant } = await setupParticipant()
+
+      await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        status: "cancelled",
+      })
+
+      const active = await getActivePaymentRequest(participant.id)
+
+      expect(active).toBeNull()
+    })
+  })
+
+  describe("markPaymentAsExpired", () => {
+    it("updates status to expired", async () => {
+      const { participant } = await setupParticipant()
+
+      const request = await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        status: "pending",
+      })
+
+      await markPaymentAsExpired(request.id)
+
+      const updated = await kysely
+        .selectFrom("payment_requests")
+        .selectAll()
+        .where("id", "=", request.id)
+        .executeTakeFirstOrThrow()
+
+      expect(updated.status).toBe("expired")
+    })
+  })
+
+  describe("payment request with profile join", () => {
+    it("can join payment_requests with event_participants and profiles", async () => {
+      const { participant } = await setupParticipant()
+
+      await createTestPaymentRequest(tracker, kysely, {
+        event_participant_id: participant.id,
+        amount: 220,
+        expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+
+      const result = await kysely
+        .selectFrom("payment_requests")
+        .innerJoin(
+          "event_participants",
+          "event_participants.id",
+          "payment_requests.event_participant_id",
+        )
+        .innerJoin("profiles", "profiles.id", "event_participants.profile_id")
+        .innerJoin("events", "events.id", "event_participants.event_id")
+        .select([
+          "payment_requests.id",
+          "payment_requests.amount",
+          "payment_requests.status",
+          "profiles.full_name",
+          "profiles.cpf",
+          "profiles.email",
+          "events.title",
+          "events.ticket_price",
+        ])
+        .where("payment_requests.event_participant_id", "=", participant.id)
+        .executeTakeFirstOrThrow()
+
+      expect(result.full_name).toBe("Test Participant")
+      expect(result.cpf).toBe("12345678900")
+      expect(result.email).toContain("payment-test-")
+      expect(result.title).toBe("Test Payment Event")
+      expect(Number(result.ticket_price)).toBe(220)
+      expect(Number(result.amount)).toBe(220)
+    })
+  })
+})

--- a/app/business/payment/payment-request.server.test.ts
+++ b/app/business/payment/payment-request.server.test.ts
@@ -401,6 +401,14 @@ describe("payment-request.server", () => {
       )
     })
 
+    it("throws when no paid manual request exists", async () => {
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(undefined))
+
+      await expect(markManualPaymentRefunded("ep-1")).rejects.toThrow(
+        "No paid manual payment request found",
+      )
+    })
+
     it("still succeeds when refund email fails", async () => {
       const refundedRequest = {
         id: "pr-1",

--- a/app/business/payment/payment-request.server.test.ts
+++ b/app/business/payment/payment-request.server.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockKyselyDb = vi.hoisted(() => ({
+  insertInto: vi.fn(),
+  selectFrom: vi.fn(),
+  updateTable: vi.fn(),
+}))
+
+vi.mock("~/kysely-db", () => ({
+  kyselyDb: mockKyselyDb,
+}))
+
+vi.mock("./asaas-client.server", () => ({
+  createAsaasCustomer: vi.fn(),
+  createAsaasPayment: vi.fn(),
+  cancelAsaasPayment: vi.fn(),
+}))
+
+vi.mock("./send-payment-refund-email.server", () => ({
+  sendPaymentRefundEmail: vi.fn().mockResolvedValue({ emailSent: true }),
+}))
+
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("./payment-pricing.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./payment-pricing.server")>()
+  return {
+    ...actual,
+  }
+})
+
+import {
+  createPaymentRequest,
+  getActivePaymentRequest,
+  cancelActivePaymentRequest,
+  confirmPaymentChoice,
+  markPaymentAsExpired,
+  markManualPaymentRefunded,
+} from "./payment-request.server"
+import { createAsaasCustomer, createAsaasPayment, cancelAsaasPayment } from "./asaas-client.server"
+import { sendPaymentRefundEmail } from "./send-payment-refund-email.server"
+
+function chainable(returnValue?: unknown) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop) {
+      if (typeof prop === "symbol") return undefined
+      if (prop === "then") return undefined
+      if (!chain[prop]) {
+        chain[prop] = vi.fn().mockReturnValue(new Proxy({}, handler))
+      }
+      if (prop === "executeTakeFirstOrThrow" || prop === "executeTakeFirst") {
+        chain[prop].mockResolvedValue(returnValue)
+      }
+      if (prop === "execute") {
+        chain[prop].mockResolvedValue(returnValue ?? [])
+      }
+      return chain[prop]
+    },
+  }
+  return new Proxy({}, handler)
+}
+
+describe("payment-request.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("createPaymentRequest", () => {
+    it("creates a pending payment request with correct defaults", async () => {
+      const now = new Date("2026-03-15T12:00:00Z")
+      vi.setSystemTime(now)
+
+      const expectedRow = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 220,
+        status: "pending",
+        expires_at: new Date("2026-03-17T12:00:00Z").toISOString(),
+        created_at: now.toISOString(),
+      }
+
+      mockKyselyDb.insertInto.mockReturnValue(chainable(expectedRow))
+
+      const result = await createPaymentRequest({
+        eventParticipantId: "ep-1",
+        ticketPrice: 220,
+      })
+
+      expect(result).toEqual(expectedRow)
+      expect(mockKyselyDb.insertInto).toHaveBeenCalledWith("payment_requests")
+
+      vi.useRealTimers()
+    })
+  })
+
+  describe("getActivePaymentRequest", () => {
+    it("returns non-expired, non-cancelled request", async () => {
+      const activeRequest = {
+        id: "pr-1",
+        status: "pending",
+        event_participant_id: "ep-1",
+      }
+
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(activeRequest))
+
+      const result = await getActivePaymentRequest("ep-1")
+
+      expect(result).toEqual(activeRequest)
+      expect(mockKyselyDb.selectFrom).toHaveBeenCalledWith("payment_requests")
+    })
+
+    it("returns null when no active request exists", async () => {
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(null))
+
+      const result = await getActivePaymentRequest("ep-1")
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("confirmPaymentChoice", () => {
+    it("creates Asaas customer and payment, updates DB, returns invoiceUrl", async () => {
+      const paymentRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 220,
+        status: "pending",
+      }
+
+      const profileData = {
+        full_name: "João Silva",
+        cpf: "12345678900",
+        email: "joao@test.com",
+        phone: 11999998888,
+      }
+
+      mockKyselyDb.selectFrom.mockReturnValueOnce(chainable(paymentRequest))
+      mockKyselyDb.selectFrom.mockReturnValueOnce(chainable(profileData))
+      mockKyselyDb.updateTable.mockReturnValue(chainable({ id: "pr-1" }))
+
+      vi.mocked(createAsaasCustomer).mockResolvedValue({ id: "cus_1" })
+      vi.mocked(createAsaasPayment).mockResolvedValue({
+        id: "pay_1",
+        invoiceUrl: "https://sandbox.asaas.com/i/pay_1",
+      })
+
+      const result = await confirmPaymentChoice({
+        eventParticipantId: "ep-1",
+        paymentOption: "CC_2",
+      })
+
+      expect(result.invoiceUrl).toBe("https://sandbox.asaas.com/i/pay_1")
+      expect(createAsaasCustomer).toHaveBeenCalledWith({
+        name: "João Silva",
+        cpfCnpj: "12345678900",
+        email: "joao@test.com",
+        phone: "11999998888",
+      })
+      expect(createAsaasPayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customerId: "cus_1",
+          billingType: "CREDIT_CARD",
+          installmentCount: 2,
+        }),
+      )
+    })
+
+    it("throws when payment request not found", async () => {
+      mockKyselyDb.selectFrom.mockReturnValueOnce(chainable(null))
+
+      await expect(
+        confirmPaymentChoice({
+          eventParticipantId: "ep-1",
+          paymentOption: "PIX",
+        }),
+      ).rejects.toThrow()
+    })
+
+    it("throws when profile has no CPF", async () => {
+      const paymentRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 220,
+        status: "pending",
+      }
+
+      mockKyselyDb.selectFrom.mockReturnValueOnce(chainable(paymentRequest))
+      mockKyselyDb.selectFrom.mockReturnValueOnce(
+        chainable({ full_name: "João", cpf: null }),
+      )
+
+      await expect(
+        confirmPaymentChoice({
+          eventParticipantId: "ep-1",
+          paymentOption: "PIX",
+        }),
+      ).rejects.toThrow("CPF")
+    })
+
+    it("uses PIX billing type and ticket price for PIX option", async () => {
+      const paymentRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 220,
+        status: "pending",
+      }
+
+      mockKyselyDb.selectFrom.mockReturnValueOnce(chainable(paymentRequest))
+      mockKyselyDb.selectFrom.mockReturnValueOnce(
+        chainable({ full_name: "João", cpf: "12345678900", email: "joao@test.com", phone: null }),
+      )
+      mockKyselyDb.updateTable.mockReturnValue(chainable({ id: "pr-1" }))
+
+      vi.mocked(createAsaasCustomer).mockResolvedValue({ id: "cus_1" })
+      vi.mocked(createAsaasPayment).mockResolvedValue({
+        id: "pay_1",
+        invoiceUrl: "https://sandbox.asaas.com/i/pay_1",
+      })
+
+      await confirmPaymentChoice({
+        eventParticipantId: "ep-1",
+        paymentOption: "PIX",
+      })
+
+      expect(createAsaasPayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          billingType: "PIX",
+          value: 220,
+        }),
+      )
+    })
+  })
+
+  describe("markPaymentAsExpired", () => {
+    it("updates status to expired", async () => {
+      mockKyselyDb.updateTable.mockReturnValue(chainable(undefined))
+
+      await markPaymentAsExpired("pr-1")
+
+      expect(mockKyselyDb.updateTable).toHaveBeenCalledWith("payment_requests")
+    })
+  })
+
+  describe("cancelActivePaymentRequest", () => {
+    it("cancels active request and calls Asaas cancel when asaas_payment_id exists", async () => {
+      const activeRequest = {
+        id: "pr-active",
+        event_participant_id: "ep-1",
+        asaas_payment_id: "pay_old",
+        status: "awaiting_payment",
+        expires_at: new Date(Date.now() + 86400000).toISOString(),
+      }
+
+      // Updated flow: DB UPDATE runs first (with WHERE status guard +
+      // returningAll), then Asaas cancel runs only if the update succeeded.
+      // The mock returns the cancelled row to simulate a matching UPDATE.
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(activeRequest))
+      mockKyselyDb.updateTable.mockReturnValue(
+        chainable({ ...activeRequest, status: "cancelled" }),
+      )
+
+      await cancelActivePaymentRequest("ep-1")
+
+      expect(cancelAsaasPayment).toHaveBeenCalledWith("pay_old")
+      expect(mockKyselyDb.updateTable).toHaveBeenCalledWith("payment_requests")
+    })
+
+    it("cancels active request without Asaas call when no asaas_payment_id", async () => {
+      const activeRequest = {
+        id: "pr-active",
+        event_participant_id: "ep-1",
+        asaas_payment_id: null,
+        status: "pending",
+        expires_at: new Date(Date.now() + 86400000).toISOString(),
+      }
+
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(activeRequest))
+      mockKyselyDb.updateTable.mockReturnValue(
+        chainable({ ...activeRequest, status: "cancelled" }),
+      )
+
+      await cancelActivePaymentRequest("ep-1")
+
+      expect(cancelAsaasPayment).not.toHaveBeenCalled()
+      expect(mockKyselyDb.updateTable).toHaveBeenCalledWith("payment_requests")
+    })
+
+    it("rolls back and throws when Asaas cancel fails (charge likely already paid)", async () => {
+      const activeRequest = {
+        id: "pr-active",
+        event_participant_id: "ep-1",
+        asaas_payment_id: "pay_old",
+        status: "awaiting_payment",
+        expires_at: new Date(Date.now() + 86400000).toISOString(),
+      }
+
+      // First UPDATE: cancel succeeds locally → returns the cancelled row.
+      // Second UPDATE: rollback → returns the restored row.
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(activeRequest))
+      mockKyselyDb.updateTable
+        .mockReturnValueOnce(chainable({ ...activeRequest, status: "cancelled" }))
+        .mockReturnValueOnce(chainable({ ...activeRequest })) // rollback
+      vi.mocked(cancelAsaasPayment).mockRejectedValueOnce(
+        new Error("Asaas API error"),
+      )
+
+      await expect(cancelActivePaymentRequest("ep-1")).rejects.toThrow(
+        "Asaas API error",
+      )
+
+      expect(cancelAsaasPayment).toHaveBeenCalledWith("pay_old")
+      // Two UPDATEs: the optimistic cancel, then the rollback
+      expect(mockKyselyDb.updateTable).toHaveBeenCalledTimes(2)
+    })
+
+    it("skips Asaas cancel when status changed concurrently (UPDATE no-op)", async () => {
+      const activeRequest = {
+        id: "pr-active",
+        event_participant_id: "ep-1",
+        asaas_payment_id: "pay_old",
+        status: "awaiting_payment",
+        expires_at: new Date(Date.now() + 86400000).toISOString(),
+      }
+
+      // UPDATE returns undefined (WHERE status IN (...) didn't match because
+      // a concurrent process flipped the row to paid/refunded/cancelled).
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(activeRequest))
+      mockKyselyDb.updateTable.mockReturnValue(chainable(undefined))
+
+      await cancelActivePaymentRequest("ep-1")
+
+      expect(cancelAsaasPayment).not.toHaveBeenCalled()
+    })
+
+    it("does nothing when no active request exists", async () => {
+      mockKyselyDb.selectFrom.mockReturnValue(chainable(null))
+
+      await cancelActivePaymentRequest("ep-1")
+
+      expect(cancelAsaasPayment).not.toHaveBeenCalled()
+      expect(mockKyselyDb.updateTable).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("markManualPaymentRefunded", () => {
+    it("sends refund notification email after marking as refunded", async () => {
+      const refundedRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 100,
+        status: "refunded",
+        payment_mode: "manual",
+      }
+
+      mockKyselyDb.updateTable.mockReturnValue(chainable(refundedRequest))
+      mockKyselyDb.selectFrom.mockReturnValue(
+        chainable({ email: "joao@test.com", full_name: "João", title: "Positiv Regular" }),
+      )
+
+      await markManualPaymentRefunded("ep-1")
+
+      expect(sendPaymentRefundEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          participantEmail: "joao@test.com",
+          participantName: "João",
+          eventName: "Positiv Regular",
+          refundAmount: 100,
+        }),
+      )
+    })
+
+    it("still succeeds when refund email fails", async () => {
+      const refundedRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 100,
+        status: "refunded",
+        payment_mode: "manual",
+      }
+
+      mockKyselyDb.updateTable.mockReturnValue(chainable(refundedRequest))
+      mockKyselyDb.selectFrom.mockReturnValue(
+        chainable({ email: "joao@test.com", full_name: "João", title: "Positiv Regular" }),
+      )
+      vi.mocked(sendPaymentRefundEmail).mockRejectedValueOnce(new Error("Email failed"))
+
+      const result = await markManualPaymentRefunded("ep-1")
+      expect(result).toEqual(refundedRequest)
+    })
+  })
+})

--- a/app/business/payment/payment-request.server.test.ts
+++ b/app/business/payment/payment-request.server.test.ts
@@ -38,6 +38,7 @@ import {
   confirmPaymentChoice,
   markPaymentAsExpired,
   markManualPaymentRefunded,
+  updatePaymentRequestAmount,
 } from "./payment-request.server"
 import { createAsaasCustomer, createAsaasPayment, cancelAsaasPayment } from "./asaas-client.server"
 import { sendPaymentRefundEmail } from "./send-payment-refund-email.server"
@@ -389,6 +390,43 @@ describe("payment-request.server", () => {
 
       const result = await markManualPaymentRefunded("ep-1")
       expect(result).toEqual(refundedRequest)
+    })
+  })
+
+  describe("updatePaymentRequestAmount", () => {
+    it("updates amount for pending manual request", async () => {
+      const updatedRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 300,
+        status: "pending",
+        payment_mode: "manual",
+      }
+
+      mockKyselyDb.updateTable.mockReturnValue(chainable(updatedRequest))
+
+      const result = await updatePaymentRequestAmount("ep-1", 300)
+      expect(result).toEqual(updatedRequest)
+    })
+
+    it("throws when amount is zero", async () => {
+      await expect(updatePaymentRequestAmount("ep-1", 0)).rejects.toThrow(
+        "Amount must be greater than zero",
+      )
+    })
+
+    it("throws when amount is negative", async () => {
+      await expect(updatePaymentRequestAmount("ep-1", -50)).rejects.toThrow(
+        "Amount must be greater than zero",
+      )
+    })
+
+    it("throws when no pending manual request exists", async () => {
+      mockKyselyDb.updateTable.mockReturnValue(chainable(undefined))
+
+      await expect(updatePaymentRequestAmount("ep-1", 300)).rejects.toThrow(
+        "No pending manual payment request found",
+      )
     })
   })
 })

--- a/app/business/payment/payment-request.server.test.ts
+++ b/app/business/payment/payment-request.server.test.ts
@@ -37,6 +37,7 @@ import {
   cancelActivePaymentRequest,
   confirmPaymentChoice,
   markPaymentAsExpired,
+  markManualPaymentPaid,
   markManualPaymentRefunded,
   updatePaymentRequestAmount,
 } from "./payment-request.server"
@@ -346,12 +347,39 @@ describe("payment-request.server", () => {
     })
   })
 
+  describe("markManualPaymentPaid", () => {
+    it("marks a pending manual payment as paid", async () => {
+      const paidRequest = {
+        id: "pr-1",
+        event_participant_id: "ep-1",
+        amount: 220,
+        status: "paid",
+        payment_mode: "manual",
+        paid_at: expect.any(String),
+      }
+
+      mockKyselyDb.updateTable.mockReturnValue(chainable(paidRequest))
+
+      const result = await markManualPaymentPaid("ep-1")
+      expect(result).toEqual(paidRequest)
+    })
+
+    it("throws when no pending manual request exists", async () => {
+      mockKyselyDb.updateTable.mockReturnValue(chainable(undefined))
+
+      await expect(markManualPaymentPaid("ep-1")).rejects.toThrow(
+        "No pending manual payment request found",
+      )
+    })
+  })
+
   describe("markManualPaymentRefunded", () => {
     it("sends refund notification email after marking as refunded", async () => {
       const refundedRequest = {
         id: "pr-1",
         event_participant_id: "ep-1",
         amount: 100,
+        refund_amount: 100,
         status: "refunded",
         payment_mode: "manual",
       }
@@ -378,6 +406,7 @@ describe("payment-request.server", () => {
         id: "pr-1",
         event_participant_id: "ep-1",
         amount: 100,
+        refund_amount: 100,
         status: "refunded",
         payment_mode: "manual",
       }

--- a/app/business/payment/payment-request.server.ts
+++ b/app/business/payment/payment-request.server.ts
@@ -172,14 +172,7 @@ export async function confirmPaymentChoice({
   eventParticipantId: string
   paymentOption: string
 }) {
-  const paymentRequest = await kyselyDb
-    .selectFrom("payment_requests")
-    .selectAll()
-    .where("event_participant_id", "=", eventParticipantId)
-    .where("status", "not in", ["expired", "cancelled"])
-    .where("expires_at", ">", new Date().toISOString())
-    .executeTakeFirst()
-
+  const paymentRequest = await getActivePaymentRequest(eventParticipantId)
   if (!paymentRequest) {
     throw new Error("No active payment request found")
   }
@@ -226,8 +219,9 @@ export async function confirmPaymentChoice({
         : undefined,
   })
 
+  let updated: unknown
   try {
-    await kyselyDb
+    updated = await kyselyDb
       .updateTable("payment_requests")
       .set({
         asaas_customer_id: customer.id,
@@ -241,11 +235,10 @@ export async function confirmPaymentChoice({
         updated_at: new Date().toISOString(),
       })
       .where("id", "=", paymentRequest.id)
-      .execute()
+      .where("status", "in", ["pending", "awaiting_payment"])
+      .returningAll()
+      .executeTakeFirst()
   } catch (dbError) {
-    // Asaas customer + charge were created but our DB doesn't know about
-    // them. Cancel the charge so we don't leave an orphaned Asaas payment
-    // that the participant could pay with no local record.
     logger.error("DB update failed after Asaas charge creation — cancelling orphaned charge", {
       paymentRequestId: paymentRequest.id,
       asaasPaymentId: payment.id,
@@ -261,6 +254,23 @@ export async function confirmPaymentChoice({
       })
     }
     throw dbError
+  }
+
+  if (!updated) {
+    logger.error("confirmPaymentChoice: status changed concurrently — cancelling orphaned charge", {
+      paymentRequestId: paymentRequest.id,
+      asaasPaymentId: payment.id,
+    })
+    try {
+      await cancelAsaasPayment(payment.id)
+    } catch (cancelError) {
+      logger.error("MANUAL RECONCILIATION REQUIRED: failed to cancel orphaned Asaas charge after race", {
+        paymentRequestId: paymentRequest.id,
+        asaasPaymentId: payment.id,
+        cancelError: cancelError instanceof Error ? cancelError.message : String(cancelError),
+      })
+    }
+    throw new Error("Payment request was concurrently modified; charge cancelled")
   }
 
   return { invoiceUrl: payment.invoiceUrl }
@@ -359,7 +369,7 @@ export async function markManualPaymentRefunded(eventParticipantId: string) {
         participantEmail: participantInfo.email,
         participantName: participantInfo.full_name ?? "Participante",
         eventName: participantInfo.title ?? "Evento Positiv",
-        refundAmount: Number(result.amount),
+        refundAmount: Number(result.refund_amount),
       })
     }
   } catch (emailError) {

--- a/app/business/payment/payment-request.server.ts
+++ b/app/business/payment/payment-request.server.ts
@@ -219,7 +219,25 @@ export async function confirmPaymentChoice({
         : undefined,
   })
 
-  let updated: unknown
+  const paymentRequestId = paymentRequest.id
+
+  async function cancelOrphanedCharge(reason: string) {
+    logger.error(reason, {
+      paymentRequestId,
+      asaasPaymentId: payment.id,
+    })
+    try {
+      await cancelAsaasPayment(payment.id)
+    } catch (cancelError) {
+      logger.error("MANUAL RECONCILIATION REQUIRED: failed to cancel orphaned Asaas charge", {
+        paymentRequestId,
+        asaasPaymentId: payment.id,
+        cancelError: cancelError instanceof Error ? cancelError.message : String(cancelError),
+      })
+    }
+  }
+
+  let updated
   try {
     updated = await kyselyDb
       .updateTable("payment_requests")
@@ -234,42 +252,17 @@ export async function confirmPaymentChoice({
         status: "awaiting_payment",
         updated_at: new Date().toISOString(),
       })
-      .where("id", "=", paymentRequest.id)
+      .where("id", "=", paymentRequestId)
       .where("status", "in", ["pending", "awaiting_payment"])
       .returningAll()
       .executeTakeFirst()
   } catch (dbError) {
-    logger.error("DB update failed after Asaas charge creation — cancelling orphaned charge", {
-      paymentRequestId: paymentRequest.id,
-      asaasPaymentId: payment.id,
-      error: dbError instanceof Error ? dbError.message : String(dbError),
-    })
-    try {
-      await cancelAsaasPayment(payment.id)
-    } catch (cancelError) {
-      logger.error("MANUAL RECONCILIATION REQUIRED: failed to cancel orphaned Asaas charge", {
-        paymentRequestId: paymentRequest.id,
-        asaasPaymentId: payment.id,
-        cancelError: cancelError instanceof Error ? cancelError.message : String(cancelError),
-      })
-    }
+    await cancelOrphanedCharge("DB update failed after Asaas charge creation — cancelling orphaned charge")
     throw dbError
   }
 
   if (!updated) {
-    logger.error("confirmPaymentChoice: status changed concurrently — cancelling orphaned charge", {
-      paymentRequestId: paymentRequest.id,
-      asaasPaymentId: payment.id,
-    })
-    try {
-      await cancelAsaasPayment(payment.id)
-    } catch (cancelError) {
-      logger.error("MANUAL RECONCILIATION REQUIRED: failed to cancel orphaned Asaas charge after race", {
-        paymentRequestId: paymentRequest.id,
-        asaasPaymentId: payment.id,
-        cancelError: cancelError instanceof Error ? cancelError.message : String(cancelError),
-      })
-    }
+    await cancelOrphanedCharge("confirmPaymentChoice: status changed concurrently — cancelling orphaned charge")
     throw new Error("Payment request was concurrently modified; charge cancelled")
   }
 

--- a/app/business/payment/payment-request.server.ts
+++ b/app/business/payment/payment-request.server.ts
@@ -1,0 +1,366 @@
+import { composable } from "composable-functions"
+import { kyselyDb } from "~/kysely-db"
+import { logger } from "~/lib/logger/logger.server"
+import {
+  cancelAsaasPayment,
+  createAsaasCustomer,
+  createAsaasPayment,
+} from "./asaas-client.server"
+import { buildPaymentOptions, MAX_INSTALLMENTS } from "./payment-pricing.server"
+import { sendPaymentRefundEmail } from "./send-payment-refund-email.server"
+
+export const PAYMENT_REQUEST_EXPIRY_MS = 2 * 24 * 60 * 60 * 1000
+
+export async function createPaymentRequest({
+  eventParticipantId,
+  ticketPrice,
+  paymentMode,
+}: {
+  eventParticipantId: string
+  ticketPrice: number
+  paymentMode?: "automatic" | "manual"
+}) {
+  const expiresAt = new Date(Date.now() + PAYMENT_REQUEST_EXPIRY_MS)
+
+  return kyselyDb
+    .insertInto("payment_requests")
+    .values({
+      event_participant_id: eventParticipantId,
+      amount: ticketPrice,
+      status: "pending",
+      payment_mode: paymentMode ?? "manual",
+      expires_at: expiresAt.toISOString(),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const getLatestPaymentRequest = composable(
+  async (eventParticipantId: string) => {
+    const result = await kyselyDb
+      .selectFrom("payment_requests")
+      .selectAll()
+      .where("event_participant_id", "=", eventParticipantId)
+      .orderBy("created_at", "desc")
+      .executeTakeFirst()
+    return result ?? null
+  },
+)
+
+export type PaymentRequestRow = NonNullable<
+  Extract<Awaited<ReturnType<typeof getLatestPaymentRequest>>, { success: true }>["data"]
+>
+
+export async function getActivePaymentRequest(eventParticipantId: string) {
+  const result = await kyselyDb
+    .selectFrom("payment_requests")
+    .selectAll()
+    .where("event_participant_id", "=", eventParticipantId)
+    .where("status", "not in", ["expired", "cancelled"])
+    .where("expires_at", ">", new Date().toISOString())
+    .executeTakeFirst()
+  return result ?? null
+}
+
+export async function cancelActivePaymentRequest(eventParticipantId: string) {
+  const active = await getActivePaymentRequest(eventParticipantId)
+  if (!active) return
+
+  // Atomic guard: only cancel if status is still non-terminal. Using
+  // returningAll() so executeTakeFirst() returns the row (or undefined
+  // when a concurrent caller already changed the status) — never
+  // Kysely's always-truthy UpdateResult.
+  const updated = await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      status: "cancelled",
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", active.id)
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!updated) {
+    // Another concurrent process already changed the status (paid via
+    // webhook, cancelled by another admin, etc.). Skip the Asaas cancel
+    // to avoid clobbering a legitimate state transition.
+    logger.info(
+      "cancelActivePaymentRequest: status changed concurrently, skipping",
+      { paymentRequestId: active.id },
+    )
+    return
+  }
+
+  if (updated.asaas_payment_id) {
+    try {
+      await cancelAsaasPayment(updated.asaas_payment_id)
+      logger.info("Cancelled Asaas payment after local cancellation", {
+        paymentRequestId: updated.id,
+        asaasPaymentId: updated.asaas_payment_id,
+      })
+    } catch (error) {
+      // Asaas refused the cancel (most likely the charge was already paid).
+      // If we leave the local row as `cancelled`, the user could still pay
+      // the live Asaas charge and our webhook handlers (which only flip
+      // pending/awaiting_payment rows) would silently no-op. Roll the local
+      // status back so the system stays consistent.
+      const rolledBack = await kyselyDb
+        .updateTable("payment_requests")
+        .set({ status: active.status, updated_at: new Date().toISOString() })
+        .where("id", "=", updated.id)
+        .where("status", "=", "cancelled")
+        .returningAll()
+        .executeTakeFirst()
+
+      if (!rolledBack) {
+        logger.error(
+          "Asaas cancel failed AND local rollback was a no-op — MANUAL RECONCILIATION REQUIRED",
+          {
+            paymentRequestId: updated.id,
+            asaasPaymentId: updated.asaas_payment_id,
+            originalStatus: active.status,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        )
+      } else {
+        logger.error(
+          "Asaas cancel failed, rolled back local status — likely the charge was already paid",
+          {
+            paymentRequestId: updated.id,
+            asaasPaymentId: updated.asaas_payment_id,
+            restoredStatus: active.status,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        )
+      }
+
+      throw error
+    }
+  }
+}
+
+function parsePaymentOption(paymentOption: string) {
+  if (paymentOption === "PIX") {
+    return { billingType: "PIX" as const, installments: 1 }
+  }
+
+  // Belt-and-suspenders with the schema enum: parsing accepts only the
+  // supported CC_1..CC_<MAX_INSTALLMENTS>. A hand-crafted POST that bypasses
+  // the schema should fail hard, not quietly accept CC_0 or out-of-range.
+  const match = paymentOption.match(/^CC_(\d+)$/)
+  const installments = match ? Number(match[1]) : NaN
+  if (
+    !match ||
+    !Number.isInteger(installments) ||
+    installments < 1 ||
+    installments > MAX_INSTALLMENTS
+  ) {
+    throw new Error(`Invalid payment option: ${paymentOption}`)
+  }
+
+  return {
+    billingType: "CREDIT_CARD" as const,
+    installments,
+  }
+}
+
+export async function confirmPaymentChoice({
+  eventParticipantId,
+  paymentOption,
+}: {
+  eventParticipantId: string
+  paymentOption: string
+}) {
+  const paymentRequest = await kyselyDb
+    .selectFrom("payment_requests")
+    .selectAll()
+    .where("event_participant_id", "=", eventParticipantId)
+    .where("status", "not in", ["expired", "cancelled"])
+    .where("expires_at", ">", new Date().toISOString())
+    .executeTakeFirst()
+
+  if (!paymentRequest) {
+    throw new Error("No active payment request found")
+  }
+
+  const amount = Number(paymentRequest.amount)
+
+  const profile = await kyselyDb
+    .selectFrom("event_participants")
+    .innerJoin("profiles", "profiles.id", "event_participants.profile_id")
+    .select(["profiles.full_name", "profiles.cpf", "profiles.email", "profiles.phone"])
+    .where("event_participants.id", "=", eventParticipantId)
+    .executeTakeFirstOrThrow()
+
+  if (!profile.cpf) {
+    throw new Error("CPF is required for payment. Please update your profile.")
+  }
+
+  const customer = await createAsaasCustomer({
+    name: profile.full_name ?? "Participante",
+    cpfCnpj: profile.cpf,
+    email: profile.email ?? undefined,
+    phone: profile.phone ? String(profile.phone) : undefined,
+  })
+
+  const { billingType, installments } = parsePaymentOption(paymentOption)
+
+  const options = buildPaymentOptions(amount)
+  const option = options.find((o) => o.value === paymentOption)
+  if (!option) throw new Error(`Invalid payment option: ${paymentOption}`)
+
+  const dueDate = new Date(Date.now() + PAYMENT_REQUEST_EXPIRY_MS)
+    .toISOString()
+    .split("T")[0]
+
+  const payment = await createAsaasPayment({
+    customerId: customer.id,
+    billingType,
+    value: option.totalReais,
+    dueDate,
+    description: "Positiv — Ingresso",
+    installmentCount:
+      billingType === "CREDIT_CARD" && installments > 1
+        ? installments
+        : undefined,
+  })
+
+  await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      asaas_customer_id: customer.id,
+      asaas_payment_id: payment.id,
+      payment_mode: "automatic",
+      payment_method: billingType,
+      installment_count: installments,
+      amount: option.totalReais,
+      invoice_url: payment.invoiceUrl,
+      status: "awaiting_payment",
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", paymentRequest.id)
+    .execute()
+
+  return { invoiceUrl: payment.invoiceUrl }
+}
+
+export async function markPaymentAsExpired(paymentRequestId: string) {
+  await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      status: "expired",
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", paymentRequestId)
+    .execute()
+}
+
+export async function markManualPaymentPaid(eventParticipantId: string) {
+  const now = new Date().toISOString()
+  const result = await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      status: "paid",
+      paid_at: now,
+      updated_at: now,
+    })
+    .where("event_participant_id", "=", eventParticipantId)
+    .where("payment_mode", "=", "manual")
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!result) {
+    throw new Error("No pending manual payment request found for this participant")
+  }
+
+  return result
+}
+
+export async function markManualPaymentRefunded(eventParticipantId: string) {
+  const now = new Date().toISOString()
+
+  // Need the current amount to set refund_amount — do a SELECT first so we
+  // don't lose audit information. The WHERE on the UPDATE still provides
+  // atomicity (only flips rows where status is still 'paid').
+  const current = await kyselyDb
+    .selectFrom("payment_requests")
+    .selectAll()
+    .where("event_participant_id", "=", eventParticipantId)
+    .where("payment_mode", "=", "manual")
+    .where("status", "=", "paid")
+    .executeTakeFirst()
+
+  if (!current) {
+    throw new Error("No paid manual payment request found for this participant")
+  }
+
+  const result = await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      status: "refunded",
+      refund_amount: current.amount,
+      refunded_at: now,
+      updated_at: now,
+    })
+    .where("id", "=", current.id)
+    .where("status", "=", "paid")
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!result) {
+    // Row flipped to another status between SELECT and UPDATE (concurrent admin).
+    throw new Error("Manual payment was concurrently modified; refund aborted")
+  }
+
+  try {
+    const participantInfo = await kyselyDb
+      .selectFrom("event_participants")
+      .innerJoin("profiles", "profiles.id", "event_participants.profile_id")
+      .innerJoin("events", "events.id", "event_participants.event_id")
+      .select(["profiles.email", "profiles.full_name", "events.title"])
+      .where("event_participants.id", "=", eventParticipantId)
+      .executeTakeFirst()
+
+    if (participantInfo?.email) {
+      await sendPaymentRefundEmail({
+        participantEmail: participantInfo.email,
+        participantName: participantInfo.full_name ?? "Participante",
+        eventName: participantInfo.title ?? "Evento Positiv",
+        refundAmount: Number(result.amount),
+      })
+    }
+  } catch (emailError) {
+    logger.error("Failed to send manual refund notification email (non-fatal)", {
+      eventParticipantId,
+      error: emailError instanceof Error ? emailError.message : String(emailError),
+    })
+  }
+
+  return result
+}
+
+export async function updatePaymentRequestAmount(eventParticipantId: string, amount: number) {
+  if (amount <= 0) {
+    throw new Error("Amount must be greater than zero")
+  }
+
+  const result = await kyselyDb
+    .updateTable("payment_requests")
+    .set({
+      amount,
+      updated_at: new Date().toISOString(),
+    })
+    .where("event_participant_id", "=", eventParticipantId)
+    .where("payment_mode", "=", "manual")
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!result) {
+    throw new Error("No pending manual payment request found for this participant")
+  }
+
+  return result
+}

--- a/app/business/payment/payment-request.server.ts
+++ b/app/business/payment/payment-request.server.ts
@@ -226,34 +226,65 @@ export async function confirmPaymentChoice({
         : undefined,
   })
 
-  await kyselyDb
-    .updateTable("payment_requests")
-    .set({
-      asaas_customer_id: customer.id,
-      asaas_payment_id: payment.id,
-      payment_mode: "automatic",
-      payment_method: billingType,
-      installment_count: installments,
-      amount: option.totalReais,
-      invoice_url: payment.invoiceUrl,
-      status: "awaiting_payment",
-      updated_at: new Date().toISOString(),
+  try {
+    await kyselyDb
+      .updateTable("payment_requests")
+      .set({
+        asaas_customer_id: customer.id,
+        asaas_payment_id: payment.id,
+        payment_mode: "automatic",
+        payment_method: billingType,
+        installment_count: installments,
+        amount: option.totalReais,
+        invoice_url: payment.invoiceUrl,
+        status: "awaiting_payment",
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", paymentRequest.id)
+      .execute()
+  } catch (dbError) {
+    // Asaas customer + charge were created but our DB doesn't know about
+    // them. Cancel the charge so we don't leave an orphaned Asaas payment
+    // that the participant could pay with no local record.
+    logger.error("DB update failed after Asaas charge creation — cancelling orphaned charge", {
+      paymentRequestId: paymentRequest.id,
+      asaasPaymentId: payment.id,
+      error: dbError instanceof Error ? dbError.message : String(dbError),
     })
-    .where("id", "=", paymentRequest.id)
-    .execute()
+    try {
+      await cancelAsaasPayment(payment.id)
+    } catch (cancelError) {
+      logger.error("MANUAL RECONCILIATION REQUIRED: failed to cancel orphaned Asaas charge", {
+        paymentRequestId: paymentRequest.id,
+        asaasPaymentId: payment.id,
+        cancelError: cancelError instanceof Error ? cancelError.message : String(cancelError),
+      })
+    }
+    throw dbError
+  }
 
   return { invoiceUrl: payment.invoiceUrl }
 }
 
 export async function markPaymentAsExpired(paymentRequestId: string) {
-  await kyselyDb
+  const result = await kyselyDb
     .updateTable("payment_requests")
     .set({
-      status: "expired",
+      status: "expired" as const,
       updated_at: new Date().toISOString(),
     })
     .where("id", "=", paymentRequestId)
-    .execute()
+    .where("status", "in", ["pending", "awaiting_payment"])
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!result) {
+    logger.info("markPaymentAsExpired: row is no longer in a non-terminal state", {
+      paymentRequestId,
+    })
+  }
+
+  return result
 }
 
 export async function markManualPaymentPaid(eventParticipantId: string) {

--- a/app/test/db-test-utils.ts
+++ b/app/test/db-test-utils.ts
@@ -299,14 +299,14 @@ export async function createTestAdminUser(
   return { userId, profile }
 }
 
-type PaymentRequestInsert = Insertable<DatabaseTypes["public"]["Tables"]["payment_requests"]["Row"]>
+type PaymentRequestInsert = DatabaseTypes["public"]["Tables"]["payment_requests"]["Insert"]
 
 export async function createTestPaymentRequest(
   tracker: TestDataTracker,
   kysely: Kysely<Database>,
-  data: Omit<PaymentRequestInsert, "expires_at"> & { expires_at?: PaymentRequestInsert["expires_at"] }
+  data: Omit<PaymentRequestInsert, "expires_at"> & { expires_at?: string }
 ): Promise<Selectable<DatabaseTypes["public"]["Tables"]["payment_requests"]["Row"]>> {
-  const values: PaymentRequestInsert = {
+  const values = {
     expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     ...data,
   }


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 7 — payment-request business logic, part of the payment system rebuild)

## Summary

Seventh atomic slice of the Sistema de Pagamentos rebuild. The core business logic module that ties DB, Asaas client, and pricing together.

### CRUD
- `createPaymentRequest`: insert with 48h expiry, default manual mode
- `getLatestPaymentRequest`: composable, most recent by created_at
- `getActivePaymentRequest`: non-expired, non-terminal status

### Atomic transitions (§3.1, §3.2)
- `cancelActivePaymentRequest`: DB-first cancel → Asaas cancel. On Asaas failure, rolls back with guarded UPDATE. If rollback no-ops, logs CRITICAL for manual reconciliation.
- `markPaymentAsExpired`, `markManualPaymentPaid`, `markManualPaymentRefunded`: status-guarded transitions with `returningAll().executeTakeFirst()`
- `updatePaymentRequestAmount`: guarded by manual + pending/awaiting

### Payment choice confirmation
- `confirmPaymentChoice`: validates option (§3.10), creates Asaas customer with profile data (email/phone), creates charge, updates DB with Asaas IDs + invoice URL

### Cherry-pick sources
- `19105175` — initial CRUD + confirmPaymentChoice
- `e364cbdf` — enforce single active request, cancel old Asaas payment
- Payment-request parts of `4da13d5c` (MEGA BLASTER) — race-safe guards, rollback pattern, `returningAll()` fix

### Adaptations for PR #2 schema changes
- `payment_mode` parameter typed as `"automatic" | "manual"` (ENUM, not string)
- `createTestPaymentRequest` helper: use Supabase Insert type instead of `Insertable<Row>` (DB-defaulted fields are properly optional)
- Integration test: simulate expired rows with past `created_at` + past `expires_at` (respects `expires_at > created_at` constraint)

## How to test manually

1. `pnpm lint` — green
2. `pnpm test` — 180 files, 1693 tests (22 new)
3. `pnpm test:integration` — includes race condition tests

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 180 files, 1693 tests pass
- `pnpm test:integration` ✅ — 30 files, 277 tests pass (7 new integration)

## Breaking Changes

None. New files + minor test helper type fix.

## Invariants touched

- §3.1 — Atomic status transitions with `returningAll().executeTakeFirst()` ✅
- §3.2 — DB UPDATE before Asaas call, with rollback on failure ✅
- §3.10 — `parsePaymentOption` validates against `MAX_INSTALLMENTS` ✅

## Rollback

`git revert` the commit. No route consumers yet — the payment page (PR #9) and admin trigger (PR #8) call these functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)