### PR TITLE
[POS-464] Trigger payment request from admin + payment link email sender

### DIFF
--- a/app/business/payment/send-payment-link-email.server.test.ts
+++ b/app/business/payment/send-payment-link-email.server.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("~/business/email/send-email", () => ({
+  sendEmail: vi.fn(),
+}))
+
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: { error: vi.fn(), info: vi.fn() },
+}))
+
+import { sendPaymentLinkEmail } from "./send-payment-link-email.server"
+import { sendEmail } from "~/business/email/send-email"
+
+const defaultParams = {
+  participantEmail: "joao@test.com",
+  participantName: "João Silva",
+  eventName: "Positiv Regular",
+  ticketPrice: 220,
+  paymentUrl: "https://www.positivparty.com/pagamento/abc-123",
+  expiresAt: new Date("2026-03-17T12:00:00Z"),
+}
+
+describe("sendPaymentLinkEmail", () => {
+  it("sends email with correct subject and recipient", async () => {
+    vi.mocked(sendEmail).mockResolvedValue({
+      success: true,
+      data: undefined,
+      errors: [],
+    })
+
+    const result = await sendPaymentLinkEmail(defaultParams)
+
+    expect(result.emailSent).toBe(true)
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "joao@test.com",
+        subject: expect.stringContaining("Positiv Regular"),
+      }),
+    )
+  })
+
+  it("returns emailSent false when sendEmail fails", async () => {
+    vi.mocked(sendEmail).mockResolvedValue({
+      success: false,
+      errors: [{ message: "SMTP error" } as never],
+    })
+
+    const result = await sendPaymentLinkEmail(defaultParams)
+
+    expect(result.emailSent).toBe(false)
+  })
+
+  it("includes html and text in email options", async () => {
+    vi.mocked(sendEmail).mockResolvedValue({
+      success: true,
+      data: undefined,
+      errors: [],
+    })
+
+    await sendPaymentLinkEmail(defaultParams)
+
+    const mailOptions = vi.mocked(sendEmail).mock.calls[0][0]
+    expect(mailOptions.html).toContain("João Silva")
+    expect(mailOptions.text).toContain("João Silva")
+  })
+})

--- a/app/business/payment/send-payment-link-email.server.ts
+++ b/app/business/payment/send-payment-link-email.server.ts
@@ -1,0 +1,51 @@
+import { formatPaymentLinkMail } from "~/business/email/format-payment-link-mail"
+import { type MailOptions, sendEmail } from "~/business/email/send-email"
+import { buildPaymentOptions } from "~/business/payment/payment-pricing.server"
+import { logger } from "~/lib/logger/logger.server"
+
+type SendPaymentLinkEmailParams = {
+  participantEmail: string
+  participantName: string
+  eventName: string
+  ticketPrice: number
+  paymentUrl: string
+  expiresAt: Date
+}
+
+export async function sendPaymentLinkEmail({
+  participantEmail,
+  participantName,
+  eventName,
+  ticketPrice,
+  paymentUrl,
+  expiresAt,
+}: SendPaymentLinkEmailParams): Promise<{ emailSent: boolean }> {
+  const paymentOptions = buildPaymentOptions(ticketPrice)
+
+  const { html, text } = formatPaymentLinkMail({
+    participantName,
+    eventName,
+    paymentOptions,
+    paymentUrl,
+    expiresAt,
+  })
+
+  const options: MailOptions = {
+    to: participantEmail,
+    subject: `💳 Link de pagamento — ${eventName}`,
+    html,
+    text,
+  }
+
+  const result = await sendEmail(options)
+
+  if (!result.success) {
+    logger.error("Payment link email failed", {
+      participantEmail,
+      errors: result.errors,
+    })
+    return { emailSent: false }
+  }
+
+  return { emailSent: true }
+}

--- a/app/business/payment/trigger-payment-request.server.test.ts
+++ b/app/business/payment/trigger-payment-request.server.test.ts
@@ -229,6 +229,10 @@ describe("resolvePaymentRequest", () => {
     const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
 
     expect(result.success).toBe(false)
+    // CPF must be validated BEFORE any DB mutation so we don't orphan
+    // a pending payment_request when the profile is incomplete.
+    expect(cancelActivePaymentRequest).not.toHaveBeenCalled()
+    expect(createPaymentRequest).not.toHaveBeenCalled()
   })
 
   it("does not require CPF when offline", async () => {

--- a/app/business/payment/trigger-payment-request.server.test.ts
+++ b/app/business/payment/trigger-payment-request.server.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockKyselyDb = vi.hoisted(() => {
+  const results: unknown[] = []
+  let callIndex = 0
+
+  function chainProxy(): unknown {
+    return new Proxy(
+      {},
+      {
+        get(_, prop) {
+          if (typeof prop === "symbol") return undefined
+          if (prop === "then") return undefined
+          if (prop === "executeTakeFirstOrThrow") {
+            return () => Promise.resolve(results[callIndex++])
+          }
+          if (prop === "executeTakeFirst") {
+            return () => Promise.resolve(results[callIndex++])
+          }
+          if (prop === "execute") return () => Promise.resolve([])
+          return () => chainProxy()
+        },
+      },
+    )
+  }
+
+  return {
+    selectFrom: () => chainProxy(),
+    insertInto: () => chainProxy(),
+    updateTable: () => chainProxy(),
+    _setResults: (r: unknown[]) => {
+      results.length = 0
+      results.push(...r)
+      callIndex = 0
+    },
+  }
+})
+
+const mockEnv = vi.hoisted(() => ({
+  paymentSystemOnline: true,
+  appUrl: "https://www.positivparty.com",
+  asaasApiKey: "test",
+  asaasApiUrl: "https://sandbox.asaas.com/api/v3",
+}))
+
+vi.mock("~/kysely-db", () => ({ kyselyDb: mockKyselyDb }))
+
+vi.mock("~/env.server", () => ({
+  env: () => mockEnv,
+}))
+
+vi.mock("./send-payment-link-email.server", () => ({
+  sendPaymentLinkEmail: vi.fn().mockResolvedValue({ emailSent: true }),
+}))
+
+vi.mock("~/lib/logger/logger.server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("./payment-request.server", () => ({
+  createPaymentRequest: vi.fn(),
+  cancelActivePaymentRequest: vi.fn(),
+}))
+
+import { resolvePaymentRequest, handlePaymentStatusChange } from "./trigger-payment-request.server"
+import { sendPaymentLinkEmail } from "./send-payment-link-email.server"
+import {
+  createPaymentRequest,
+  cancelActivePaymentRequest,
+} from "./payment-request.server"
+
+const newPaymentRequest = {
+  id: "pr-new",
+  event_participant_id: "ep-1",
+  amount: 220,
+  status: "pending" as const,
+  expires_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  asaas_customer_id: null,
+  asaas_payment_id: null,
+  installment_count: null,
+  invoice_url: null,
+  paid_at: null,
+  payment_method: null as "PIX" | "CREDIT_CARD" | null,
+  payment_mode: "manual" as const,
+  refund_amount: null,
+  refunded_at: null,
+}
+
+describe("handlePaymentStatusChange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnv.paymentSystemOnline = true
+    vi.mocked(createPaymentRequest).mockResolvedValue(newPaymentRequest)
+    vi.mocked(cancelActivePaymentRequest).mockResolvedValue(undefined)
+  })
+
+  it("returns triggered: false when status is not sent_payment_data", async () => {
+    const result = await handlePaymentStatusChange({
+      applicationStatus: "pending",
+      eventParticipantId: "ep-1",
+      eventId: "ev-1",
+      profileId: "pr-1",
+    })
+
+    expect(result.triggered).toBe(false)
+    expect(sendPaymentLinkEmail).not.toHaveBeenCalled()
+  })
+
+  it("returns triggered: false when status is undefined", async () => {
+    const result = await handlePaymentStatusChange({
+      applicationStatus: undefined,
+      eventParticipantId: "ep-1",
+      eventId: "ev-1",
+      profileId: "pr-1",
+    })
+
+    expect(result.triggered).toBe(false)
+  })
+
+  it("returns triggered: true with success when status is sent_payment_data", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+      { id: "pr-1", email: "joao@test.com", full_name: "João", cpf: "12345678900" },
+    ])
+
+    const result = await handlePaymentStatusChange({
+      applicationStatus: "sent_payment_data",
+      eventParticipantId: "ep-1",
+      eventId: "ev-1",
+      profileId: "pr-1",
+    })
+
+    expect(result.triggered).toBe(true)
+    if (result.triggered) expect(result.success).toBe(true)
+  })
+
+  it("returns triggered: true with failure when resolvePaymentRequest fails", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Free Event", ticket_price: null },
+    ])
+
+    const result = await handlePaymentStatusChange({
+      applicationStatus: "sent_payment_data",
+      eventParticipantId: "ep-1",
+      eventId: "ev-1",
+      profileId: "pr-1",
+    })
+
+    expect(result.triggered).toBe(true)
+    if (result.triggered) expect(result.success).toBe(false)
+  })
+})
+
+describe("resolvePaymentRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnv.paymentSystemOnline = true
+    vi.mocked(createPaymentRequest).mockResolvedValue(newPaymentRequest)
+    vi.mocked(cancelActivePaymentRequest).mockResolvedValue(undefined)
+  })
+
+  it("cancels any existing active request before creating a new one", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+      { id: "pr-1", email: "joao@test.com", full_name: "João", cpf: "12345678900" },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(true)
+    expect(cancelActivePaymentRequest).toHaveBeenCalledWith("ep-1")
+    expect(createPaymentRequest).toHaveBeenCalledWith({
+      eventParticipantId: "ep-1",
+      ticketPrice: 220,
+      paymentMode: "automatic",
+    })
+  })
+
+  it("creates payment request and sends email when online", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+      { id: "pr-1", email: "joao@test.com", full_name: "João", cpf: "12345678900" },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(true)
+    expect(sendPaymentLinkEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participantEmail: "joao@test.com",
+        participantName: "João",
+        eventName: "Positiv Regular",
+        ticketPrice: 220,
+      }),
+    )
+  })
+
+  it("creates manual payment request without email when offline", async () => {
+    mockEnv.paymentSystemOnline = false
+
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(true)
+    expect(sendPaymentLinkEmail).not.toHaveBeenCalled()
+  })
+
+  it("returns failure when event has no ticket_price", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Free Event", ticket_price: null },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(false)
+  })
+
+  it("returns failure when profile has no CPF (online only)", async () => {
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+      { id: "pr-1", email: "joao@test.com", full_name: "João", cpf: null },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(false)
+  })
+
+  it("does not require CPF when offline", async () => {
+    mockEnv.paymentSystemOnline = false
+
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1")
+
+    expect(result.success).toBe(true)
+  })
+
+  it("uses paymentMode=automatic to override feature flag when provided", async () => {
+    mockEnv.paymentSystemOnline = false
+
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+      { id: "pr-1", email: "joao@test.com", full_name: "João", cpf: "12345678900" },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1", undefined, "automatic")
+
+    expect(result.success).toBe(true)
+    expect(sendPaymentLinkEmail).toHaveBeenCalled()
+  })
+
+  it("uses paymentMode=manual to override feature flag when provided", async () => {
+    mockEnv.paymentSystemOnline = true
+
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+    ])
+
+    const result = await resolvePaymentRequest("ep-1", "ev-1", "pr-1", undefined, "manual")
+
+    expect(result.success).toBe(true)
+    expect(sendPaymentLinkEmail).not.toHaveBeenCalled()
+  })
+
+  it("passes paymentMode from handlePaymentStatusChange to resolvePaymentRequest", async () => {
+    mockEnv.paymentSystemOnline = true
+
+    mockKyselyDb._setResults([
+      { id: "ev-1", title: "Positiv Regular", ticket_price: 220 },
+    ])
+
+    const result = await handlePaymentStatusChange({
+      applicationStatus: "sent_payment_data",
+      eventParticipantId: "ep-1",
+      eventId: "ev-1",
+      profileId: "pr-1",
+      paymentMode: "manual",
+    })
+
+    expect(result.triggered).toBe(true)
+    if (result.triggered) expect(result.success).toBe(true)
+    expect(sendPaymentLinkEmail).not.toHaveBeenCalled()
+  })
+})

--- a/app/business/payment/trigger-payment-request.server.test.ts
+++ b/app/business/payment/trigger-payment-request.server.test.ts
@@ -287,6 +287,9 @@ describe("resolvePaymentRequest", () => {
 
     expect(result.triggered).toBe(true)
     if (result.triggered) expect(result.success).toBe(true)
+    expect(createPaymentRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentMode: "manual" }),
+    )
     expect(sendPaymentLinkEmail).not.toHaveBeenCalled()
   })
 })

--- a/app/business/payment/trigger-payment-request.server.ts
+++ b/app/business/payment/trigger-payment-request.server.ts
@@ -9,19 +9,13 @@ import {
 } from "./payment-request.server"
 import { sendPaymentLinkEmail } from "./send-payment-link-email.server"
 
-/**
- * Called from admin action handlers when application_status changes.
- * Only triggers payment when status is "sent_payment_data".
- * Returns { triggered: false } for other statuses,
- * or { triggered: true, success, errors } when payment was attempted.
- */
 export async function handlePaymentStatusChange(fields: {
   applicationStatus: string | undefined
   eventParticipantId: string
   eventId: string
   profileId: string
   customAmount?: number
-  paymentMode?: string
+  paymentMode?: "automatic" | "manual"
 }) {
   if (fields.applicationStatus !== "sent_payment_data") {
     return { triggered: false as const }
@@ -52,7 +46,7 @@ export const resolvePaymentRequest = composable(
     eventId: string,
     profileId: string,
     customAmount?: number,
-    paymentMode?: string,
+    paymentMode?: "automatic" | "manual",
   ) => {
     const isPaymentSystemOnline = paymentMode
       ? paymentMode === "automatic"
@@ -98,14 +92,22 @@ export const resolvePaymentRequest = composable(
     const { appUrl } = env()
     const paymentUrl = `${appUrl}${paths.payment.PAYMENT(eventParticipantId)}`
 
-    await sendPaymentLinkEmail({
-      participantEmail: profile.email,
-      participantName: profile.full_name ?? "Participante",
-      eventName: event.title ?? "Evento Positiv",
-      ticketPrice: Number(paymentRequest.amount),
-      paymentUrl,
-      expiresAt: new Date(paymentRequest.expires_at),
-    })
+    try {
+      await sendPaymentLinkEmail({
+        participantEmail: profile.email,
+        participantName: profile.full_name ?? "Participante",
+        eventName: event.title ?? "Evento Positiv",
+        ticketPrice: Number(paymentRequest.amount),
+        paymentUrl,
+        expiresAt: new Date(paymentRequest.expires_at),
+      })
+    } catch (emailError) {
+      logger.error("Failed to send payment link email (non-fatal)", {
+        eventParticipantId,
+        paymentRequestId: paymentRequest.id,
+        error: emailError instanceof Error ? emailError.message : String(emailError),
+      })
+    }
 
     logger.info("Payment request resolved", {
       eventParticipantId,

--- a/app/business/payment/trigger-payment-request.server.ts
+++ b/app/business/payment/trigger-payment-request.server.ts
@@ -1,0 +1,117 @@
+import { composable } from "composable-functions"
+import { env } from "~/env.server"
+import { kyselyDb } from "~/kysely-db"
+import { logger } from "~/lib/logger/logger.server"
+import paths from "~/lib/paths"
+import {
+  cancelActivePaymentRequest,
+  createPaymentRequest,
+} from "./payment-request.server"
+import { sendPaymentLinkEmail } from "./send-payment-link-email.server"
+
+/**
+ * Called from admin action handlers when application_status changes.
+ * Only triggers payment when status is "sent_payment_data".
+ * Returns { triggered: false } for other statuses,
+ * or { triggered: true, success, errors } when payment was attempted.
+ */
+export async function handlePaymentStatusChange(fields: {
+  applicationStatus: string | undefined
+  eventParticipantId: string
+  eventId: string
+  profileId: string
+  customAmount?: number
+  paymentMode?: string
+}) {
+  if (fields.applicationStatus !== "sent_payment_data") {
+    return { triggered: false as const }
+  }
+
+  const result = await resolvePaymentRequest(
+    fields.eventParticipantId,
+    fields.eventId,
+    fields.profileId,
+    fields.customAmount,
+    fields.paymentMode,
+  )
+
+  if (!result.success) {
+    logger.error("Failed to resolve payment request", {
+      errors: result.errors,
+      eventId: fields.eventId,
+      profileId: fields.profileId,
+    })
+  }
+
+  return { triggered: true as const, ...result }
+}
+
+export const resolvePaymentRequest = composable(
+  async (
+    eventParticipantId: string,
+    eventId: string,
+    profileId: string,
+    customAmount?: number,
+    paymentMode?: string,
+  ) => {
+    const isPaymentSystemOnline = paymentMode
+      ? paymentMode === "automatic"
+      : env().paymentSystemOnline
+
+    const event = await kyselyDb
+      .selectFrom("events")
+      .select(["id", "title", "ticket_price"])
+      .where("id", "=", eventId)
+      .executeTakeFirstOrThrow()
+
+    const amount = customAmount ?? Number(event.ticket_price)
+    if (!amount) {
+      throw new Error(`Event ${eventId} has no ticket_price configured and no custom amount provided`)
+    }
+
+    await cancelActivePaymentRequest(eventParticipantId)
+
+    const paymentRequest = await createPaymentRequest({
+      eventParticipantId,
+      ticketPrice: amount,
+      paymentMode: isPaymentSystemOnline ? "automatic" : "manual",
+    })
+
+    if (!isPaymentSystemOnline) {
+      logger.info("Payment request created as manual (payment system offline)", {
+        eventParticipantId,
+        paymentRequestId: paymentRequest.id,
+      })
+      return paymentRequest
+    }
+
+    const profile = await kyselyDb
+      .selectFrom("profiles")
+      .select(["id", "email", "full_name", "cpf"])
+      .where("id", "=", profileId)
+      .executeTakeFirstOrThrow()
+
+    if (!profile.cpf) {
+      throw new Error(`Profile ${profileId} has no CPF. Payment requires a valid CPF.`)
+    }
+
+    const { appUrl } = env()
+    const paymentUrl = `${appUrl}${paths.payment.PAYMENT(eventParticipantId)}`
+
+    await sendPaymentLinkEmail({
+      participantEmail: profile.email,
+      participantName: profile.full_name ?? "Participante",
+      eventName: event.title ?? "Evento Positiv",
+      ticketPrice: Number(paymentRequest.amount),
+      paymentUrl,
+      expiresAt: new Date(paymentRequest.expires_at),
+    })
+
+    logger.info("Payment request resolved", {
+      eventParticipantId,
+      paymentRequestId: paymentRequest.id,
+    })
+
+    return paymentRequest
+  },
+)

--- a/app/business/payment/trigger-payment-request.server.ts
+++ b/app/business/payment/trigger-payment-request.server.ts
@@ -63,6 +63,29 @@ export const resolvePaymentRequest = composable(
       throw new Error(`Event ${eventId} has no ticket_price configured and no custom amount provided`)
     }
 
+    // Online mode: validate profile + CPF BEFORE any DB mutations. A missing
+    // CPF would otherwise throw after we've cancelled the old request and
+    // created a new one, leaving the participant with an orphaned pending row.
+    let profile:
+      | {
+          id: string
+          email: string
+          full_name: string | null
+          cpf: string | null
+        }
+      | undefined
+    if (isPaymentSystemOnline) {
+      profile = await kyselyDb
+        .selectFrom("profiles")
+        .select(["id", "email", "full_name", "cpf"])
+        .where("id", "=", profileId)
+        .executeTakeFirstOrThrow()
+
+      if (!profile.cpf) {
+        throw new Error(`Profile ${profileId} has no CPF. Payment requires a valid CPF.`)
+      }
+    }
+
     await cancelActivePaymentRequest(eventParticipantId)
 
     const paymentRequest = await createPaymentRequest({
@@ -79,14 +102,10 @@ export const resolvePaymentRequest = composable(
       return paymentRequest
     }
 
-    const profile = await kyselyDb
-      .selectFrom("profiles")
-      .select(["id", "email", "full_name", "cpf"])
-      .where("id", "=", profileId)
-      .executeTakeFirstOrThrow()
-
-    if (!profile.cpf) {
-      throw new Error(`Profile ${profileId} has no CPF. Payment requires a valid CPF.`)
+    // Invariant: profile is defined here because isPaymentSystemOnline === true
+    // (see the profile fetch + CPF validation above).
+    if (!profile) {
+      throw new Error("Profile not loaded — unreachable")
     }
 
     const { appUrl } = env()

--- a/app/lib/paths.ts
+++ b/app/lib/paths.ts
@@ -52,11 +52,18 @@ const ADMIN_CREATE_EVENT = `${ADMIN_EVENTS}/novo`
 const ADMIN_EVENT_VIEW_PARTICIPANT = (eventId: string, participantId: string) =>
   `${ADMIN_EVENTS}/${eventId}/participantes/${participantId}`
 
+const PAYMENT = (eventParticipantId: string) => `/pagamento/${eventParticipantId}`
+const PAYMENT_THANK_YOU = "/pagamento/obrigado"
+
 const paths = {
   root: {
     HOME,
     CODE_OF_CONDUCT,
     FEEDBACK,
+  },
+  payment: {
+    PAYMENT,
+    PAYMENT_THANK_YOU,
   },
   admin: {
     ADMIN_DASHBOARD,


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 8 — trigger payment request, part of the payment system rebuild)

## Summary

Eighth atomic slice of the Sistema de Pagamentos rebuild. Adds the orchestration layer that ties admin actions to payment request creation + email notification.

### Trigger logic (`trigger-payment-request.server.ts`)
- `handlePaymentStatusChange`: entry point for admin action handlers — dispatches when `application_status` changes to `"sent_payment_data"`. Returns `{ triggered, success, errors }`.
- `resolvePaymentRequest` (composable): cancels any active request, creates a new one, and sends the payment link email. Supports:
  - **Online mode** (`PAYMENT_SYSTEM_ONLINE=true`): creates automatic payment request, validates CPF, sends email with payment URL
  - **Offline mode** (`PAYMENT_SYSTEM_ONLINE=false`): creates manual payment request, skips Asaas/email
  - **Custom amounts**: optional override for per-participant pricing
  - **Explicit payment mode**: caller can force automatic/manual regardless of feature flag

### Payment link email sender (`send-payment-link-email.server.ts`)
Deferred from PR #5 because it depends on `buildPaymentOptions` (PR #6). Now that the pricing engine is merged, this completes the email system:
- Builds payment options from ticket price
- Formats HTML + text email via the payment link template
- Sends via `sendEmail` composable

### Payment paths
Added `paths.payment.PAYMENT(eventParticipantId)` and `PAYMENT_THANK_YOU` to `paths.ts` — used for constructing the payment URL in emails.

### Deferred
- `processRefund` → PR #10 (Refund flow)
- Admin UI wiring (view-event-participant action, data-table handler) → PR #12

### Cherry-pick sources
- `32934cf0` — trigger on sent_payment_data status change
- `32a7be54` — manual mode when payment system offline
- `74f942c1` — handlePaymentStatusChange shared helper
- Trigger parts of `4da13d5c` (MEGA BLASTER) — requireAdmin enforcement context

## How to test manually

1. `pnpm lint` — green
2. `pnpm test` — 182 files, 1716 tests pass (16 new)

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 182 files, 1716 tests pass
- `pnpm test:integration` ✅ — 30 files, 277 tests pass

## Breaking Changes

None. New files + paths addition.

## Rollback

`git revert` the commit. No admin UI consumers yet — the wiring happens in PR #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)