### PR TITLE
[POS-464] Admin UI: payment status section + resend + refund + cancel + requireAdmin

### DIFF
--- a/app/components/pages/admin/participants/participant-detail.tsx
+++ b/app/components/pages/admin/participants/participant-detail.tsx
@@ -1,4 +1,5 @@
 import type { ProfileWithExtraData } from "~/business/admin/admin.server"
+import type { PaymentRequestRow } from "~/business/payment/payment-request.server"
 import { ApprovalStatusDropdown } from "~/components/molecules/approval-status-dropdown/approval-status-dropdown"
 import { Card, CardContent } from "~/components/ui/card"
 import { getAge } from "~/lib/helpers/get-age"
@@ -20,12 +21,14 @@ type ParticipantDetailProps = {
     data: EventParticipantWithEvent
     eventId: string
   }
+  paymentRequest?: PaymentRequestRow | null
 }
 
 export const ParticipantDetail = ({
   profile,
   fullHistory,
   currentEvent,
+  paymentRequest,
 }: ParticipantDetailProps) => {
   const name = profile.social_name || profile.full_name
   // ProfileWithExtraData has profile_id from event_participants join (id is overwritten)
@@ -63,7 +66,10 @@ export const ParticipantDetail = ({
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
           <Card className="lg:col-span-3 py-4">
             <CardContent>
-              <ParticipantVsEventData eventParticipant={currentEvent.data} />
+              <ParticipantVsEventData
+                eventParticipant={currentEvent.data}
+                paymentRequest={paymentRequest}
+              />
             </CardContent>
           </Card>
           <div className="lg:col-span-2 space-y-4">

--- a/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
@@ -116,13 +116,6 @@ describe("ParticipantVsEventData", () => {
       expect(screen.getByLabelText(/pagamento/i)).toBeInTheDocument()
     })
 
-    it("should render has_paid checkbox", () => {
-      const router = createTestRouter(mockEventParticipant)
-      render(<RouterProvider router={router} />)
-
-      expect(screen.getByLabelText(/pago/i)).toBeInTheDocument()
-    })
-
     it("should render admin_general_notes textarea", () => {
       const router = createTestRouter(mockEventParticipant)
       render(<RouterProvider router={router} />)
@@ -151,22 +144,6 @@ describe("ParticipantVsEventData", () => {
       const formData = mockFetcher.submit.mock.calls[0][0] as FormData
       expect(formData.get("attendance_status")).toBe("attended")
       expect(formData.get("intent")).toBe("update-event-participant")
-    })
-
-    it("should auto-save when has_paid checkbox changes", async () => {
-      const user = userEvent.setup()
-      const router = createTestRouter(mockEventParticipant)
-      render(<RouterProvider router={router} />)
-
-      const checkbox = screen.getByLabelText(/pago/i)
-      await user.click(checkbox)
-
-      await waitFor(() => {
-        expect(mockFetcher.submit).toHaveBeenCalled()
-      })
-
-      const formData = mockFetcher.submit.mock.calls[0][0] as FormData
-      expect(formData.get("has_paid")).toBe("true")
     })
 
     it("should auto-save admin_general_notes on blur", async () => {

--- a/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { createMemoryRouter, RouterProvider } from "react-router"
 import { toast } from "sonner"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { PaymentRequestRow } from "~/business/payment/payment-request.server"
 import type { EventParticipantWithEvent } from "~types/database/entities.types"
 import { ParticipantVsEventData } from "./participant-vs-event-data"
 
@@ -63,11 +64,19 @@ const mockEventParticipant: EventParticipantWithEvent = {
   was_selected_for_rotation: false,
 }
 
-const createTestRouter = (eventParticipant: EventParticipantWithEvent) => {
+const createTestRouter = (
+  eventParticipant: EventParticipantWithEvent,
+  paymentRequest?: PaymentRequestRow | null,
+) => {
   return createMemoryRouter([
     {
       path: "/",
-      element: <ParticipantVsEventData eventParticipant={eventParticipant} />,
+      element: (
+        <ParticipantVsEventData
+          eventParticipant={eventParticipant}
+          paymentRequest={paymentRequest}
+        />
+      ),
     },
   ])
 }
@@ -209,6 +218,72 @@ describe("ParticipantVsEventData", () => {
       render(<RouterProvider router={router} />)
 
       expect(screen.getByText("Test notes")).toBeInTheDocument()
+    })
+  })
+
+  describe("payment status section", () => {
+    const paidRequest: PaymentRequestRow = {
+      id: "pr-1",
+      event_participant_id: "123",
+      amount: 220,
+      status: "paid",
+      payment_mode: "automatic",
+      payment_method: "PIX",
+      installment_count: 1,
+      asaas_customer_id: "cus_1",
+      asaas_payment_id: "pay_1",
+      invoice_url: "https://sandbox.asaas.com/i/pay_1",
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+      paid_at: new Date().toISOString(),
+      refund_amount: null,
+      refunded_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+
+    it("renders Payment Status Section when paymentRequest exists", () => {
+      const router = createTestRouter(mockEventParticipant, paidRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(screen.getByRole("heading", { level: 4, name: /pagamento/i })).toBeInTheDocument()
+    })
+
+    it("renders Reembolsar button when status is paid with Asaas id", () => {
+      const router = createTestRouter(mockEventParticipant, paidRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(screen.getByRole("button", { name: /reembolsar/i })).toBeInTheDocument()
+    })
+
+    it("renders Cancelar pagamento button when status is awaiting_payment (automatic)", () => {
+      const awaitingRequest: PaymentRequestRow = {
+        ...paidRequest,
+        status: "awaiting_payment",
+        paid_at: null,
+      }
+      const router = createTestRouter(mockEventParticipant, awaitingRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(screen.getByRole("button", { name: /cancelar pagamento/i })).toBeInTheDocument()
+    })
+
+    it("does NOT render cancel button when status is paid", () => {
+      const router = createTestRouter(mockEventParticipant, paidRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(screen.queryByRole("button", { name: /cancelar pagamento/i })).not.toBeInTheDocument()
+    })
+
+    it("does NOT render Reembolsar button when status is not paid", () => {
+      const pendingRequest: PaymentRequestRow = {
+        ...paidRequest,
+        status: "pending",
+        paid_at: null,
+      }
+      const router = createTestRouter(mockEventParticipant, pendingRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(screen.queryByRole("button", { name: /reembolsar/i })).not.toBeInTheDocument()
     })
   })
 })

--- a/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
@@ -285,5 +285,20 @@ describe("ParticipantVsEventData", () => {
 
       expect(screen.queryByRole("button", { name: /reembolsar/i })).not.toBeInTheDocument()
     })
+
+    it("renders Reenviar link button when status is sent_payment_data and payment is pending automatic", () => {
+      const awaitingRequest: PaymentRequestRow = {
+        ...paidRequest,
+        status: "awaiting_payment",
+        paid_at: null,
+      }
+      const router = createTestRouter(
+        { ...mockEventParticipant, application_status: "sent_payment_data" },
+        awaitingRequest,
+      )
+      render(<RouterProvider router={router} />)
+
+      expect(screen.getByRole("button", { name: /reenviar link/i })).toBeInTheDocument()
+    })
   })
 })

--- a/app/components/pages/admin/participants/participant-vs-event-data.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useState } from "react"
 import { useFetcher } from "react-router"
 import { toast } from "sonner"
 import { z } from "zod"
+import type { PaymentRequestRow } from "~/business/payment/payment-request.server"
 import { DataPair } from "~/components/atoms/data-pair/data-pair"
 import {
   AlertDialog,
@@ -36,7 +37,6 @@ import {
   spotTypeOptions,
 } from "~/lib/helpers/propMaps"
 import { useAutoSaveForm } from "~/lib/hooks/use-auto-save-form"
-import type { PaymentRequestRow } from "~/business/payment/payment-request.server"
 import type {
   ComposableFetcherData,
   EventParticipantWithEvent,
@@ -92,6 +92,7 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
   const resendFetcher = useFetcher<ComposableFetcherData>()
   const cancelFetcher = useFetcher<ComposableFetcherData>()
   const manualFetcher = useFetcher<ComposableFetcherData>()
+  const refundFetcher = useFetcher<ComposableFetcherData>()
   const [useCustomAmount, setUseCustomAmount] = useState(false)
   const [customAmount, setCustomAmount] = useState("")
   const [paymentMode, setPaymentMode] = useState<string>(
@@ -120,8 +121,6 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
     if (useCustomAmount && customAmount) formData.set("custom_amount", customAmount)
     resendFetcher.submit(formData, { method: "POST" })
   }
-
-  const refundFetcher = useFetcher<ComposableFetcherData>()
 
   const handleRefund = () => {
     const formData = new FormData()
@@ -189,6 +188,10 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
   useEffect(() => {
     if (resendFetcher.data?.paymentSent === true) {
       toast.success("Link de pagamento reenviado com sucesso")
+      // Clear the custom-amount inputs so a subsequent resend doesn't
+      // reuse stale values the admin didn't intend to send again.
+      setUseCustomAmount(false)
+      setCustomAmount("")
     }
     if (resendFetcher.data?.paymentSent === false) {
       toast.error("Erro ao reenviar link de pagamento. Tente novamente.", { duration: Infinity, closeButton: true })
@@ -305,6 +308,7 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
                   <Checkbox
                     checked={useCustomAmount}
                     onChange={(e) => setUseCustomAmount(e.target.checked)}
+                    aria-label="Valor customizado"
                   />
                   <span className="text-sm text-muted-foreground">Valor customizado</span>
                   {useCustomAmount && (

--- a/app/components/pages/admin/participants/participant-vs-event-data.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.tsx
@@ -1,7 +1,20 @@
-import type { FC } from "react"
+import { type FC, useEffect, useState } from "react"
 import { useFetcher } from "react-router"
+import { toast } from "sonner"
 import { z } from "zod"
 import { DataPair } from "~/components/atoms/data-pair/data-pair"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog"
+import { Button } from "~/components/ui/button"
 import { Checkbox } from "~/components/ui/checkbox"
 import { Input } from "~/components/ui/input"
 import { Label } from "~/components/ui/label"
@@ -18,9 +31,12 @@ import {
   applicationStatusOptions,
   attendanceStatusOptions,
   eventParticipantPropMap,
+  paymentModePropMap,
+  paymentStatusPropMap,
   spotTypeOptions,
 } from "~/lib/helpers/propMaps"
 import { useAutoSaveForm } from "~/lib/hooks/use-auto-save-form"
+import type { PaymentRequestRow } from "~/business/payment/payment-request.server"
 import type {
   ComposableFetcherData,
   EventParticipantWithEvent,
@@ -30,18 +46,30 @@ const eventParticipantFormSchema = z.object({
   attendance_status: z.string(),
   application_status: z.string(),
   spot_type: z.string(),
-  payment: z.coerce.number().min(0, "O valor não pode ser negativo"),
-  has_paid: z.boolean(),
   was_selected_for_rotation: z.boolean(),
   admin_general_notes: z.string(),
 })
 
 type ParticipantVsEventDataProps = {
   eventParticipant: EventParticipantWithEvent
+  paymentRequest?: PaymentRequestRow | null
+}
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  PIX: "Pix",
+  CREDIT_CARD: "Cartão de Crédito",
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value)
 }
 
 export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
   eventParticipant,
+  paymentRequest,
 }) => {
   const {
     id,
@@ -51,8 +79,6 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
     attendance_status,
     application_status,
     spot_type,
-    payment,
-    has_paid,
     was_selected_for_rotation,
     admin_general_notes,
     bond,
@@ -63,6 +89,128 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
   } = eventParticipant
 
   const fetcher = useFetcher<ComposableFetcherData>()
+  const resendFetcher = useFetcher<ComposableFetcherData>()
+  const cancelFetcher = useFetcher<ComposableFetcherData>()
+  const manualFetcher = useFetcher<ComposableFetcherData>()
+  const [useCustomAmount, setUseCustomAmount] = useState(false)
+  const [customAmount, setCustomAmount] = useState("")
+  const [paymentMode, setPaymentMode] = useState<string>(
+    paymentRequest?.payment_mode ?? "automatic",
+  )
+  const [manualAmount, setManualAmount] = useState(
+    paymentRequest ? String(Number(paymentRequest.amount)) : "",
+  )
+
+  const handleResendPaymentLink = () => {
+    const formData = new FormData()
+    formData.set("intent", "resend-payment-link")
+    formData.set("id", id)
+    formData.set("event_id", event_id)
+    formData.set("profile_id", profile_id ?? "")
+    if (useCustomAmount && customAmount) formData.set("custom_amount", customAmount)
+    resendFetcher.submit(formData, { method: "POST" })
+  }
+
+  const refundFetcher = useFetcher<ComposableFetcherData>()
+
+  const handleRefund = () => {
+    const formData = new FormData()
+    formData.set("intent", "refund-payment")
+    formData.set("id", id)
+    formData.set("event_id", event_id)
+    formData.set("profile_id", profile_id ?? "")
+    refundFetcher.submit(formData, { method: "POST" })
+  }
+
+  const handleMarkManualPaid = () => {
+    const formData = new FormData()
+    formData.set("intent", "mark-manual-payment-paid")
+    formData.set("id", id)
+    manualFetcher.submit(formData, { method: "POST" })
+  }
+
+  const handleMarkManualRefunded = () => {
+    const formData = new FormData()
+    formData.set("intent", "mark-manual-payment-refunded")
+    formData.set("id", id)
+    manualFetcher.submit(formData, { method: "POST" })
+  }
+
+  const handleCancelPayment = () => {
+    const formData = new FormData()
+    formData.set("intent", "cancel-payment")
+    formData.set("id", id)
+    cancelFetcher.submit(formData, { method: "POST" })
+  }
+
+  const handleUpdateManualAmount = () => {
+    const amount = Number(manualAmount)
+    if (!amount || amount <= 0) {
+      toast.error("O valor deve ser maior que zero")
+      return
+    }
+    const formData = new FormData()
+    formData.set("intent", "update-manual-payment-amount")
+    formData.set("id", id)
+    formData.set("amount", String(amount))
+    manualFetcher.submit(formData, { method: "POST" })
+  }
+
+  const isResending = resendFetcher.state !== "idle"
+  const isCancelling = cancelFetcher.state !== "idle"
+  const isRefunding = refundFetcher.state !== "idle"
+  const isManualProcessing = manualFetcher.state !== "idle"
+
+  const isAutomatic = paymentRequest?.payment_mode === "automatic"
+  const isManual = paymentRequest?.payment_mode === "manual"
+  const isPendingPayment = paymentRequest != null &&
+    (paymentRequest.status === "pending" || paymentRequest.status === "awaiting_payment")
+  const isPaid = paymentRequest?.status === "paid"
+
+  useEffect(() => {
+    if (fetcher.data?.paymentSent === true) {
+      toast.success("Link de pagamento enviado com sucesso")
+    }
+    if (fetcher.data?.paymentSent === false) {
+      toast.error("Dados atualizados, mas houve um erro ao enviar o link de pagamento. Tente novamente.", { duration: Infinity, closeButton: true })
+    }
+  }, [fetcher.data])
+
+  useEffect(() => {
+    if (resendFetcher.data?.paymentSent === true) {
+      toast.success("Link de pagamento reenviado com sucesso")
+    }
+    if (resendFetcher.data?.paymentSent === false) {
+      toast.error("Erro ao reenviar link de pagamento. Tente novamente.", { duration: Infinity, closeButton: true })
+    }
+  }, [resendFetcher.data])
+
+  useEffect(() => {
+    if (cancelFetcher.data?.success === true) {
+      toast.success("Pagamento cancelado com sucesso")
+    }
+    if (cancelFetcher.data?.success === false) {
+      toast.error("Erro ao cancelar pagamento. Tente novamente.", { duration: Infinity, closeButton: true })
+    }
+  }, [cancelFetcher.data])
+
+  useEffect(() => {
+    if (refundFetcher.data?.success === true) {
+      toast.success("Reembolso realizado com sucesso")
+    }
+    if (refundFetcher.data?.success === false) {
+      toast.error("Erro ao processar reembolso. Tente novamente.", { duration: Infinity, closeButton: true })
+    }
+  }, [refundFetcher.data])
+
+  useEffect(() => {
+    if (manualFetcher.data?.success === true) {
+      toast.success("Pagamento atualizado com sucesso")
+    }
+    if (manualFetcher.data?.success === false) {
+      toast.error("Erro ao atualizar pagamento. Tente novamente.", { duration: Infinity, closeButton: true })
+    }
+  }, [manualFetcher.data])
 
   const { register } = useAutoSaveForm({
     schema: eventParticipantFormSchema,
@@ -70,8 +218,6 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
       attendance_status,
       application_status,
       spot_type,
-      payment: payment ?? 0,
-      has_paid,
       was_selected_for_rotation,
       admin_general_notes: admin_general_notes ?? "",
     },
@@ -83,6 +229,12 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
       formData.set("profile_id", profile_id ?? "")
       formData.set("event_id", event_id)
       formData.set(field, String(value))
+      if (field === "application_status" && value === "sent_payment_data") {
+        formData.set("payment_mode", paymentMode)
+        if (useCustomAmount && customAmount) {
+          formData.set("custom_amount", customAmount)
+        }
+      }
       fetcher.submit(formData, { method: "POST" })
     },
   })
@@ -114,18 +266,47 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
 
               <div className="space-y-2">
                 <Label htmlFor="application_status">Status de Inscrição</Label>
-                <Select {...register.select("application_status")}>
-                  <SelectTrigger id="application_status">
-                    <SelectValue placeholder="Selecione..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {applicationStatusOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <div className="flex gap-2">
+                  <Select {...register.select("application_status")}>
+                    <SelectTrigger id="application_status">
+                      <SelectValue placeholder="Selecione..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {applicationStatusOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {application_status === "sent_payment_data" && isAutomatic && isPendingPayment && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleResendPaymentLink}
+                      disabled={isResending}
+                      className="shrink-0 self-center"
+                    >
+                      {isResending ? "Enviando..." : "Reenviar link"}
+                    </Button>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <Checkbox
+                    checked={useCustomAmount}
+                    onChange={(e) => setUseCustomAmount(e.target.checked)}
+                  />
+                  <span className="text-sm text-muted-foreground">Valor customizado</span>
+                  {useCustomAmount && (
+                    <Input
+                      type="number"
+                      placeholder="R$"
+                      value={customAmount}
+                      onChange={(e) => setCustomAmount(e.target.value)}
+                      className="w-28"
+                    />
+                  )}
+                </div>
               </div>
             </div>
 
@@ -147,23 +328,53 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="payment">Pagamento</Label>
-                <Input
-                  id="payment"
-                  type="number"
-                  {...register.number("payment")}
-                />
+                <Label htmlFor="payment_mode_select">Tipo de Pagamento</Label>
+                <Select
+                  value={paymentMode}
+                  onValueChange={setPaymentMode}
+                >
+                  <SelectTrigger id="payment_mode_select">
+                    <SelectValue placeholder="Selecione..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="automatic">Automático</SelectItem>
+                    <SelectItem value="manual">Manual</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
 
               <div className="flex flex-col justify-end gap-2">
                 <Label className="flex items-center gap-2 cursor-pointer">
-                  <Checkbox {...register.checkbox("has_paid")} />
-                  <span>Pago</span>
-                </Label>
-                <Label className="flex items-center gap-2 cursor-pointer">
                   <Checkbox {...register.checkbox("was_selected_for_rotation")} />
                   <span>Selecionado para Rodízio</span>
                 </Label>
+                {isPaid && isAutomatic && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={isRefunding}
+                      >
+                        {isRefunding ? "Processando..." : "Reembolsar"}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Confirmar reembolso</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Tem certeza que deseja reembolsar este pagamento? Esta ação não pode ser desfeita.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleRefund}>
+                          Confirmar reembolso
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
               </div>
             </div>
 
@@ -177,6 +388,187 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
                 placeholder="Notas administrativas para este evento..."
               />
             </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h4>Pagamento</h4>
+          <div className="bg-muted/50 rounded-lg p-4 space-y-2 text-sm">
+            {!paymentRequest ? (
+              <p className="text-muted-foreground">Sem pagamento até o momento</p>
+            ) : (
+              <>
+                <DataPair
+                  pair={[
+                    "Status",
+                    paymentStatusPropMap(paymentRequest.status),
+                  ]}
+                />
+                <DataPair
+                  pair={[
+                    "Modo",
+                    paymentModePropMap(paymentRequest.payment_mode),
+                  ]}
+                />
+                {paymentRequest.payment_method && (
+                  <DataPair
+                    pair={[
+                      "Método",
+                      PAYMENT_METHOD_LABELS[paymentRequest.payment_method] ?? paymentRequest.payment_method,
+                    ]}
+                  />
+                )}
+                <DataPair
+                  pair={[
+                    "Valor",
+                    formatCurrency(Number(paymentRequest.amount)),
+                  ]}
+                />
+              {paymentRequest.installment_count && paymentRequest.installment_count > 1 && (
+                <DataPair
+                  pair={["Parcelas", `${paymentRequest.installment_count}x`]}
+                />
+              )}
+              {paymentRequest.invoice_url && (
+                <div className="flex gap-2">
+                  <span className="text-muted-foreground">Link Asaas:</span>
+                  <a
+                    href={paymentRequest.invoice_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline"
+                  >
+                    Abrir
+                  </a>
+                </div>
+              )}
+              {paymentRequest.paid_at && (
+                <DataPair
+                  pair={[
+                    "Pago em",
+                    formatDateTime(paymentRequest.paid_at).full,
+                  ]}
+                />
+              )}
+              {paymentRequest.refunded_at && (
+                <DataPair
+                  pair={[
+                    "Reembolsado em",
+                    formatDateTime(paymentRequest.refunded_at).full,
+                  ]}
+                />
+              )}
+
+              {isAutomatic && isPendingPayment && (
+                <div className="mt-3 pt-3 border-t">
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={isCancelling}
+                      >
+                        {isCancelling ? "Cancelando..." : "Cancelar pagamento"}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Cancelar pagamento</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Tem certeza que deseja cancelar este pagamento? O link de pagamento será invalidado.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Voltar</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleCancelPayment}>
+                          Confirmar cancelamento
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              )}
+
+              {isManual && (
+                <div className="mt-3 pt-3 border-t space-y-3">
+                  {isPendingPayment && (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <Label htmlFor="manual_amount" className="shrink-0">Valor:</Label>
+                        <Input
+                          id="manual_amount"
+                          type="number"
+                          value={manualAmount}
+                          onChange={(e) => setManualAmount(e.target.value)}
+                          className="w-28"
+                        />
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleUpdateManualAmount}
+                          disabled={isManualProcessing}
+                        >
+                          Salvar valor
+                        </Button>
+                      </div>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            variant="default"
+                            size="sm"
+                            disabled={isManualProcessing}
+                          >
+                            {isManualProcessing ? "Processando..." : "Marcar como pago"}
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Confirmar pagamento manual</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Tem certeza que deseja marcar este pagamento como pago?
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                            <AlertDialogAction onClick={handleMarkManualPaid}>
+                              Confirmar pagamento
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    </>
+                  )}
+                  {isPaid && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          disabled={isManualProcessing}
+                        >
+                          {isManualProcessing ? "Processando..." : "Marcar como reembolsado"}
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Confirmar reembolso manual</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Tem certeza que deseja marcar este pagamento como reembolsado?
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                          <AlertDialogAction onClick={handleMarkManualRefunded}>
+                            Confirmar reembolso
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
+                </div>
+              )}
+              </>
+            )}
           </div>
         </div>
 

--- a/app/components/pages/admin/participants/participant-vs-event-data.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.tsx
@@ -101,6 +101,16 @@ export const ParticipantVsEventData: FC<ParticipantVsEventDataProps> = ({
     paymentRequest ? String(Number(paymentRequest.amount)) : "",
   )
 
+  // Keep local state in sync with the loader — after revalidation
+  // (e.g. following a cancel/refund/resend), paymentRequest changes and
+  // the dropdown default + amount input should reflect the new row.
+  useEffect(() => {
+    setPaymentMode(paymentRequest?.payment_mode ?? "automatic")
+    setManualAmount(
+      paymentRequest ? String(Number(paymentRequest.amount)) : "",
+    )
+  }, [paymentRequest?.id, paymentRequest?.payment_mode, paymentRequest?.amount])
+
   const handleResendPaymentLink = () => {
     const formData = new FormData()
     formData.set("intent", "resend-payment-link")

--- a/app/lib/helpers/propMaps.ts
+++ b/app/lib/helpers/propMaps.ts
@@ -228,6 +228,29 @@ export const hasPaidOptions: Array<{
   value: value,
 }))
 
+const paymentRequestStatusMap: Record<string, string> = {
+  pending: "Pendente",
+  awaiting_payment: "Aguardando pagamento",
+  paid: "Pago",
+  expired: "Expirado",
+  refunded: "Reembolsado",
+  partially_refunded: "Parcialmente reembolsado",
+  cancelled: "Cancelado",
+}
+
+export const paymentStatusPropMap = (status: string): string => {
+  return paymentRequestStatusMap[status] || status
+}
+
+const paymentModeMap: Record<string, string> = {
+  automatic: "Automático",
+  manual: "Manual",
+}
+
+export const paymentModePropMap = (mode: string): string => {
+  return paymentModeMap[mode] || mode
+}
+
 export const PARTICIPANTS_TABLE_FILTER_CONFIGS = {
   application_status: {
     storageKey: "admin-participants-filter-application-status",

--- a/app/pages/admin/events/view-event-participant/view-event-participant.tsx
+++ b/app/pages/admin/events/view-event-participant/view-event-participant.tsx
@@ -109,14 +109,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (intent === "resend-payment-link") {
     const entries = Object.fromEntries(formData)
     const id = entries.id as string
-    if (!id) return { success: false }
+    const eventId = entries.event_id as string
+    const profileId = entries.profile_id as string
+    if (!id || !eventId || !profileId) return { success: false }
     const customAmount = entries.custom_amount
       ? Number(entries.custom_amount)
       : undefined
     const result = await resolvePaymentRequest(
       id,
-      entries.event_id as string,
-      entries.profile_id as string,
+      eventId,
+      profileId,
       customAmount,
     )
     return {

--- a/app/pages/admin/events/view-event-participant/view-event-participant.tsx
+++ b/app/pages/admin/events/view-event-participant/view-event-participant.tsx
@@ -108,11 +108,13 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (intent === "resend-payment-link") {
     const entries = Object.fromEntries(formData)
+    const id = entries.id as string
+    if (!id) return { success: false }
     const customAmount = entries.custom_amount
       ? Number(entries.custom_amount)
       : undefined
     const result = await resolvePaymentRequest(
-      entries.id as string,
+      id,
       entries.event_id as string,
       entries.profile_id as string,
       customAmount,
@@ -125,14 +127,18 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (intent === "refund-payment") {
     const entries = Object.fromEntries(formData)
-    const result = await processRefund(entries.id as string)
+    const id = entries.id as string
+    if (!id) return { success: false }
+    const result = await processRefund(id)
     return { success: result.success }
   }
 
   if (intent === "mark-manual-payment-paid") {
     const entries = Object.fromEntries(formData)
+    const id = entries.id as string
+    if (!id) return { success: false }
     try {
-      await markManualPaymentPaid(entries.id as string)
+      await markManualPaymentPaid(id)
       return { success: true }
     } catch {
       return { success: false }
@@ -141,8 +147,10 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (intent === "mark-manual-payment-refunded") {
     const entries = Object.fromEntries(formData)
+    const id = entries.id as string
+    if (!id) return { success: false }
     try {
-      await markManualPaymentRefunded(entries.id as string)
+      await markManualPaymentRefunded(id)
       return { success: true }
     } catch {
       return { success: false }
@@ -151,8 +159,10 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (intent === "cancel-payment") {
     const entries = Object.fromEntries(formData)
+    const id = entries.id as string
+    if (!id) return { success: false }
     try {
-      await cancelActivePaymentRequest(entries.id as string)
+      await cancelActivePaymentRequest(id)
       return { success: true }
     } catch {
       return { success: false }
@@ -161,12 +171,14 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (intent === "update-manual-payment-amount") {
     const entries = Object.fromEntries(formData)
+    const id = entries.id as string
+    if (!id) return { success: false }
     const amount = Number(entries.amount)
-    if (isNaN(amount) || amount < 0) {
+    if (isNaN(amount) || amount <= 0) {
       return { success: false }
     }
     try {
-      await updatePaymentRequestAmount(entries.id as string, amount)
+      await updatePaymentRequestAmount(id, amount)
       return { success: true }
     } catch {
       return { success: false }

--- a/app/pages/admin/events/view-event-participant/view-event-participant.tsx
+++ b/app/pages/admin/events/view-event-participant/view-event-participant.tsx
@@ -80,15 +80,27 @@ export async function action({ request, params }: Route.ActionArgs) {
     if (entries.application_status !== "sent_payment_data")
       return { success: true }
 
+    const id = entries.id as string
+    const eventId = entries.event_id as string
+    const profileId = entries.profile_id as string
+    if (!id || !eventId || !profileId) {
+      return {
+        success: false,
+        errors: {
+          _global: ["Dados do participante incompletos. Recarregue a página."],
+        },
+      }
+    }
+
     // When application_status changes to "sent_payment_data", we create a payment request
     // and send the payment link email. If this fails, we return success: false even though
     // the DB update succeeded — because from the admin's perspective, the intent was to
     // trigger payment and that part failed. The auto-save form will show the error toast.
     const payment = await handlePaymentStatusChange({
       applicationStatus: entries.application_status as string | undefined,
-      eventParticipantId: entries.id as string,
-      eventId: entries.event_id as string,
-      profileId: entries.profile_id as string,
+      eventParticipantId: id,
+      eventId,
+      profileId,
       customAmount: entries.custom_amount ? Number(entries.custom_amount) : undefined,
       paymentMode: entries.payment_mode as "automatic" | "manual" | undefined,
     })

--- a/app/pages/admin/events/view-event-participant/view-event-participant.tsx
+++ b/app/pages/admin/events/view-event-participant/view-event-participant.tsx
@@ -1,20 +1,31 @@
-import { formAction } from "remix-forms"
 import type { ShouldRevalidateFunctionArgs } from "react-router"
-import { redirectWithError, redirectWithSuccess } from "remix-toast"
+import { redirectWithError } from "remix-toast"
+import { getUserContext } from "~/business/auth/auth.server"
+import { requireAdmin } from "~/business/auth/guards.server"
 import {
   getEventParticipantBasic,
   getParticipantFullEventHistory,
   getProfileById,
   updateEventParticipantById,
-  updateParticipantVsEvent,
   updateProfileAdminNotes,
   updateProfileApprovalStatus,
 } from "~/business/admin/admin.server"
-import { updateParticipantVsEventSchema } from "~/business/admin/common"
-import paths from "~/lib/paths"
-import type { Route } from "./+types/view-event-participant"
-import type { ParticipantEventHistoryData } from "~types/database/entities.types"
+import {
+  cancelActivePaymentRequest,
+  getLatestPaymentRequest,
+  markManualPaymentPaid,
+  markManualPaymentRefunded,
+  updatePaymentRequestAmount,
+} from "~/business/payment/payment-request.server"
+import {
+  handlePaymentStatusChange,
+  processRefund,
+  resolvePaymentRequest,
+} from "~/business/payment/trigger-payment-request.server"
 import { ParticipantDetail } from "~/components/pages/admin/participants/participant-detail"
+import paths from "~/lib/paths"
+import type { ParticipantEventHistoryData } from "~types/database/entities.types"
+import type { Route } from "./+types/view-event-participant"
 
 const {
   admin: {
@@ -34,40 +45,132 @@ export function shouldRevalidate({
   return hasParamsChanged || defaultShouldRevalidate
 }
 
-export async function action({ request }: Route.ActionArgs) {
+export async function action({ request, params }: Route.ActionArgs) {
+  // Layout loader-level admin checks do NOT gate actions in React Router 7:
+  // the action runs before loaders revalidate. Enforce admin role here
+  // so mutation side effects require authorization.
+  const { currentProfile } = await getUserContext(request, params)
+  requireAdmin(currentProfile)
+
   const formData = await request.formData()
   const intent = formData.get("intent")
 
   if (intent === "update-profile-approval-status") {
-    const result = await updateProfileApprovalStatus(Object.fromEntries(formData))
+    const result = await updateProfileApprovalStatus(
+      Object.fromEntries(formData),
+    )
     return { success: result.success }
   }
 
   if (intent === "update-profile-admin-notes") {
     const result = await updateProfileAdminNotes(Object.fromEntries(formData))
-    return { success: result.success, errors: result.success ? undefined : result.errors }
+    return {
+      success: result.success,
+      errors: result.success ? undefined : result.errors,
+    }
   }
 
   if (intent === "update-event-participant") {
-    const result = await updateEventParticipantById(Object.fromEntries(formData))
-    return { success: result.success, errors: result.success ? undefined : result.errors }
+    const entries = Object.fromEntries(formData)
+    const result = await updateEventParticipantById(entries)
+    if (!result.success) {
+      return { success: false, errors: result.errors }
+    }
+
+    if (entries.application_status !== "sent_payment_data")
+      return { success: true }
+
+    // When application_status changes to "sent_payment_data", we create a payment request
+    // and send the payment link email. If this fails, we return success: false even though
+    // the DB update succeeded — because from the admin's perspective, the intent was to
+    // trigger payment and that part failed. The auto-save form will show the error toast.
+    const payment = await handlePaymentStatusChange({
+      applicationStatus: entries.application_status as string | undefined,
+      eventParticipantId: entries.id as string,
+      eventId: entries.event_id as string,
+      profileId: entries.profile_id as string,
+      customAmount: entries.custom_amount ? Number(entries.custom_amount) : undefined,
+      paymentMode: entries.payment_mode as "automatic" | "manual" | undefined,
+    })
+    if (payment.triggered && !payment.success) {
+      return {
+        success: false,
+        errors: {
+          _global: [
+            "Status atualizado, mas houve um erro ao enviar o link de pagamento. Tente novamente.",
+          ],
+        },
+      }
+    }
+
+    return { success: true, paymentSent: true }
   }
 
-  if (intent === "participant-vs-event-schema") {
-    return formAction({
-      request: new Request(request.url, {
-        method: "POST",
-        body: formData,
-      }),
-      schema: updateParticipantVsEventSchema,
-      mutation: updateParticipantVsEvent,
-      transformResult: async (result) => {
-        if (result.success) {
-          throw await redirectWithSuccess(request.url, "Atualizado com sucesso")
-        }
-        return result
-      },
-    })
+  if (intent === "resend-payment-link") {
+    const entries = Object.fromEntries(formData)
+    const customAmount = entries.custom_amount
+      ? Number(entries.custom_amount)
+      : undefined
+    const result = await resolvePaymentRequest(
+      entries.id as string,
+      entries.event_id as string,
+      entries.profile_id as string,
+      customAmount,
+    )
+    return {
+      success: result.success,
+      paymentSent: result.success,
+    }
+  }
+
+  if (intent === "refund-payment") {
+    const entries = Object.fromEntries(formData)
+    const result = await processRefund(entries.id as string)
+    return { success: result.success }
+  }
+
+  if (intent === "mark-manual-payment-paid") {
+    const entries = Object.fromEntries(formData)
+    try {
+      await markManualPaymentPaid(entries.id as string)
+      return { success: true }
+    } catch {
+      return { success: false }
+    }
+  }
+
+  if (intent === "mark-manual-payment-refunded") {
+    const entries = Object.fromEntries(formData)
+    try {
+      await markManualPaymentRefunded(entries.id as string)
+      return { success: true }
+    } catch {
+      return { success: false }
+    }
+  }
+
+  if (intent === "cancel-payment") {
+    const entries = Object.fromEntries(formData)
+    try {
+      await cancelActivePaymentRequest(entries.id as string)
+      return { success: true }
+    } catch {
+      return { success: false }
+    }
+  }
+
+  if (intent === "update-manual-payment-amount") {
+    const entries = Object.fromEntries(formData)
+    const amount = Number(entries.amount)
+    if (isNaN(amount) || amount < 0) {
+      return { success: false }
+    }
+    try {
+      await updatePaymentRequestAmount(entries.id as string, amount)
+      return { success: true }
+    } catch {
+      return { success: false }
+    }
   }
 }
 
@@ -101,7 +204,10 @@ export async function loader({ params }: Route.LoaderArgs) {
   const profile = profileResult.data
 
   if (!eventParticipantResult.success || !eventParticipantResult.data) {
-    console.error("Error fetching event participant:", eventParticipantResult.errors)
+    console.error(
+      "Error fetching event participant:",
+      eventParticipantResult.errors,
+    )
     return redirectWithError(
       "Participante não inscrite neste evento.",
       ADMIN_VIEW_EVENT(eventId),
@@ -110,27 +216,33 @@ export async function loader({ params }: Route.LoaderArgs) {
 
   const eventParticipant = eventParticipantResult.data
 
-  // Get full participant history
-  let fullHistory: ParticipantEventHistoryData[] = []
-  const historyResult = await getParticipantFullEventHistory({
-    profileId: profile.id,
-    excludeEventId: eventId,
-  })
+  const [historyResult, paymentRequestResult] = await Promise.all([
+    getParticipantFullEventHistory({
+      profileId: profile.id,
+      excludeEventId: eventId,
+    }),
+    getLatestPaymentRequest(eventParticipant.id),
+  ])
 
-  if (historyResult.success) {
-    fullHistory = historyResult.data
-  }
+  const fullHistory: ParticipantEventHistoryData[] = historyResult.success
+    ? historyResult.data
+    : []
+
+  const paymentRequest = paymentRequestResult.success
+    ? paymentRequestResult.data
+    : null
 
   return {
     profile,
     eventParticipant,
     fullHistory,
     eventId,
+    paymentRequest,
   }
 }
 
 const ViewEventParticipant = ({ loaderData }: Route.ComponentProps) => {
-  const { eventParticipant, profile, fullHistory, eventId } = loaderData
+  const { eventParticipant, profile, fullHistory, eventId, paymentRequest } = loaderData
 
   if (!profile) return null
 
@@ -142,6 +254,7 @@ const ViewEventParticipant = ({ loaderData }: Route.ComponentProps) => {
         data: eventParticipant,
         eventId,
       }}
+      paymentRequest={paymentRequest}
     />
   )
 }

--- a/app/pages/admin/events/view-event-participant/view-event-participant.tsx
+++ b/app/pages/admin/events/view-event-participant/view-event-participant.tsx
@@ -184,6 +184,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       return { success: false }
     }
   }
+
+  // Unknown intent — fail closed so the caller gets a deterministic response.
+  return { success: false }
 }
 
 export async function loader({ params }: Route.LoaderArgs) {

--- a/app/types/database/entities.types.ts
+++ b/app/types/database/entities.types.ts
@@ -19,6 +19,7 @@ export type ComposableFetcherData =
       success: boolean
       intent: string
       errors?: Record<"_global", string[]>
+      paymentSent?: boolean
     }
   | undefined
 


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 12 — admin UI, part of the payment system rebuild)

## Summary

Twelfth atomic slice of the Sistema de Pagamentos rebuild. Wires the admin participant detail page into the payment business logic: Payment Status Section, resend/refund/cancel buttons, and — critically — `requireAdmin` enforcement on the action handler.

### `participant-vs-event-data.tsx` additions
- **Payment Status Section** showing `payment_request` data (status, billing type, amount, installments, invoice URL, paid/refunded dates) under the form
- **"Reenviar link"** button next to `application_status` when status is `sent_payment_data` → `resolvePaymentRequest`
- **"Reembolsar"** button with AlertDialog confirmation when `has_paid` is true → `processRefund`
- **Cancel** button for automatic payments in pending/awaiting_payment → `cancelActivePaymentRequest`
- Payment-specific toasts (success + error with dismiss-only for errors)

### `view-event-participant.tsx` action handlers
New intents: `resend-payment-link`, `refund-payment`, `cancel-payment`, `mark-paid`, `update-payment-amount`.

**`requireAdmin` enforcement (§3.3):** The layout-level admin loader does NOT gate POSTs in React Router 7 — the action runs before loaders revalidate. Without an explicit `requireAdmin` call inside the action, any logged-in user could POST `intent=refund-payment` and trigger admin mutations. Fix: `requireAdmin(currentProfile)` at the top of the action, before any intent dispatch.

### Supporting changes
- `paymentStatusPropMap` + `paymentModePropMap` in `propMaps.ts` (Portuguese labels for status/mode)
- `paymentSent` field on `ComposableFetcherData` (toast trigger from the data-table)
- `participant-detail.tsx` forwards `paymentRequest` prop to the child component

### Cherry-pick sources
- `9b8e803d` — resend button + toast
- `46773eee` — refund button + AlertDialog
- `ab85e265` — Payment Status Section
- `64219b31` — cancel button + action handler
- Admin-auth parts of `4da13d5c` (MEGA BLASTER) — `requireAdmin`

Files taken at state `64219b31` (last PR #12 commit chronologically).

## Known scope-edge

The `has_paid` checkbox was removed from the admin UI as part of the admin rebuild included in state `64219b31` (the rebuild crossed PR boundaries in the original branch). **The DB column is still present** — PR #14 will drop it + clean up any remaining code refs. Two tests that asserted the checkbox rendered were removed.

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 182 files, 1721 tests pass (-2 has_paid checkbox tests)
- `pnpm test:integration` ✅ — 31 files, 278 tests pass

## Breaking Changes

None for the data layer. Admin UI changes visibly (has_paid checkbox → Payment Status Section), but there's no external consumer that relies on the old UI.

## Invariants touched

Per [§3 Critical Invariants](docs/payment-system-architecture.md#3-critical-invariants-do-not-break):

- §3.3 — All admin actions MUST `requireAdmin` ✅

## Rollback

`git revert` the commit. The new action handlers disappear; the Payment Status Section disappears from the participant detail page. No DB migration involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)