### PR TITLE
[POS-464, POS-470] Manual payment UI tests (feature already live; closing DoD gap)

### DIFF
--- a/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
+++ b/app/components/pages/admin/participants/participant-vs-event-data.test.tsx
@@ -438,4 +438,126 @@ describe("ParticipantVsEventData", () => {
       expect(formData.get("custom_amount")).toBe("180")
     })
   })
+
+  describe("manual payment flow", () => {
+    const pendingManualRequest: PaymentRequestRow = {
+      id: "pr-manual-1",
+      event_participant_id: "123",
+      amount: 220,
+      status: "pending",
+      payment_mode: "manual",
+      payment_method: null,
+      installment_count: null,
+      asaas_customer_id: null,
+      asaas_payment_id: null,
+      invoice_url: null,
+      expires_at: "2099-12-31T00:00:00.000Z",
+      paid_at: null,
+      refund_amount: null,
+      refunded_at: null,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    }
+
+    const paidManualRequest: PaymentRequestRow = {
+      ...pendingManualRequest,
+      status: "paid",
+      paid_at: "2026-01-02T00:00:00.000Z",
+    }
+
+    it('renders "Marcar como pago" when payment_mode=manual and status is pending', () => {
+      const router = createTestRouter(mockEventParticipant, pendingManualRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(
+        screen.getByRole("button", { name: /marcar como pago/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('does NOT render "Marcar como pago" for automatic payment mode', () => {
+      const pendingAutomatic: PaymentRequestRow = {
+        ...pendingManualRequest,
+        payment_mode: "automatic",
+      }
+      const router = createTestRouter(mockEventParticipant, pendingAutomatic)
+      render(<RouterProvider router={router} />)
+
+      expect(
+        screen.queryByRole("button", { name: /marcar como pago/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders "Marcar como reembolsado" only for paid manual payments', () => {
+      const router = createTestRouter(mockEventParticipant, paidManualRequest)
+      render(<RouterProvider router={router} />)
+
+      expect(
+        screen.getByRole("button", { name: /marcar como reembolsado/i }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /marcar como pago/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("submits mark-manual-payment-paid intent after the confirmation dialog", async () => {
+      const user = userEvent.setup()
+      const router = createTestRouter(mockEventParticipant, pendingManualRequest)
+      render(<RouterProvider router={router} />)
+
+      await user.click(screen.getByRole("button", { name: /marcar como pago/i }))
+      await user.click(
+        await screen.findByRole("button", { name: /^confirmar pagamento$/i }),
+      )
+
+      await waitFor(() => {
+        expect(mockFetcher.submit).toHaveBeenCalled()
+      })
+
+      const formData = mockFetcher.submit.mock.calls[0][0] as FormData
+      expect(formData.get("intent")).toBe("mark-manual-payment-paid")
+      expect(formData.get("id")).toBe("123")
+    })
+
+    it("submits mark-manual-payment-refunded intent after the confirmation dialog", async () => {
+      const user = userEvent.setup()
+      const router = createTestRouter(mockEventParticipant, paidManualRequest)
+      render(<RouterProvider router={router} />)
+
+      await user.click(
+        screen.getByRole("button", { name: /marcar como reembolsado/i }),
+      )
+      await user.click(
+        await screen.findByRole("button", { name: /^confirmar reembolso$/i }),
+      )
+
+      await waitFor(() => {
+        expect(mockFetcher.submit).toHaveBeenCalled()
+      })
+
+      const formData = mockFetcher.submit.mock.calls[0][0] as FormData
+      expect(formData.get("intent")).toBe("mark-manual-payment-refunded")
+      expect(formData.get("id")).toBe("123")
+    })
+
+    it("submits update-manual-payment-amount intent with the typed value", async () => {
+      const user = userEvent.setup()
+      const router = createTestRouter(mockEventParticipant, pendingManualRequest)
+      render(<RouterProvider router={router} />)
+
+      const input = screen.getByLabelText("Valor:") as HTMLInputElement
+      await user.clear(input)
+      await user.type(input, "175")
+
+      await user.click(screen.getByRole("button", { name: /salvar valor/i }))
+
+      await waitFor(() => {
+        expect(mockFetcher.submit).toHaveBeenCalled()
+      })
+
+      const formData = mockFetcher.submit.mock.calls[0][0] as FormData
+      expect(formData.get("intent")).toBe("update-manual-payment-amount")
+      expect(formData.get("id")).toBe("123")
+      expect(formData.get("amount")).toBe("175")
+    })
+  })
 })


### PR DESCRIPTION
## Linear Ticket

Fixes POS-464 (slice 13 — manual payment mode) / Fixes POS-470

## Summary

Same pattern as PR #582: the manual payment mode feature is already **functionally complete** on \`payment\`, and this PR adds the missing UI test coverage. No production code changes.

### What's already live
- **Offline → manual request**: `resolvePaymentRequest` creates `payment_mode=manual` when `PAYMENT_SYSTEM_ONLINE=false` (PR #8)
- **Business logic**: `markManualPaymentPaid`, `markManualPaymentRefunded`, `updatePaymentRequestAmount` (PR #7, with unit tests)
- **Admin UI buttons**: "Marcar como pago", "Marcar como reembolsado", "Salvar valor" inside the Payment Status Section (PR #12)
- **Action handler intents**: `mark-manual-payment-paid`, `mark-manual-payment-refunded`, `update-manual-payment-amount` (PR #12)

### Source commit status
- `32a7be54` ("manual mode when offline") — applied via PR #8 cherry-pick
- `cf95e70c` (`syncManualPaymentStatus`) — obsoleted: the function synced `event_participants.has_paid` → `payment_requests`, but PR #12's admin rebuild removed the `has_paid` checkbox. The sync function itself was later removed in PR #14's `56b5eea6` on the original branch

### Tests added (6 UI)
- "Marcar como pago" button renders only when `payment_mode=manual` + pending/awaiting
- Button does NOT render for automatic payment mode (negative case)
- "Marcar como reembolsado" renders only for paid manual payments
- `mark-manual-payment-paid` intent fires with `id` after AlertDialog confirmation
- `mark-manual-payment-refunded` intent fires with `id` after AlertDialog confirmation
- `update-manual-payment-amount` intent carries the typed value

## Why no production changes

Both PR #13 source commits are non-actionable given the current state of `payment` (one was already cherry-picked earlier; the other's supporting UI was removed by PR #12's rebuild). POS-470's manual-payment capability is working and was just missing UI test coverage — flagged explicitly by PR #12's reviewer as "add before slice 14 closes the DB column."

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ — 182 files, 1744 tests pass (+6 new UI)
- `pnpm test:integration` ✅ — 31 files, 278 tests pass

## Breaking Changes

None. Tests only.

## Rollback

`git revert` the commit. Tests disappear; feature remains functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)